### PR TITLE
patch request

### DIFF
--- a/contrib/hbcurl/core.c
+++ b/contrib/hbcurl/core.c
@@ -824,8 +824,10 @@ HB_FUNC( CURL_EASY_SETOPT )
 
                if( HB_ISCHAR( 3 ) )
                {
-                  hb_curl->pErr = fopen( hb_parc( 3 ), "a"  );
-                  res = curl_easy_setopt( hb_curl->curl, CURLOPT_STDERR, hb_curl->pErr );
+                  hb_curl->pErr = hb_fopen( hb_parc( 3 ), "a"  );
+				  
+				  if ( hb_curl->pErr  )
+					res = curl_easy_setopt( hb_curl->curl, CURLOPT_STDERR, hb_curl->pErr );
                }
 
                break;
@@ -1046,7 +1048,7 @@ HB_FUNC( CURL_EASY_SETOPT )
                }
             }
             break;
-            case HB_CURLOPT_HTTPPOST_VALUE:
+            case HB_CURLOPT_HTTPPOST_CONTENT:
             {
                PHB_ITEM pArray = hb_param( 3, HB_IT_ARRAY );
 

--- a/contrib/hbcurl/core.c
+++ b/contrib/hbcurl/core.c
@@ -120,9 +120,7 @@ typedef struct _HB_CURL
 
    PHB_HASH_TABLE pHash;
 
-   FILE * pErr;
-
-
+   FILE*           pErr;
 } HB_CURL, * PHB_CURL;
 
 
@@ -542,8 +540,8 @@ static void PHB_CURL_free( PHB_CURL hb_curl, HB_BOOL bFree )
       curl_easy_reset( hb_curl->curl );
 #endif
 
-   if( hb_curl->pErr )
-      fclose( hb_curl->pErr );
+	if (hb_curl->pErr) 
+		fclose( hb_curl->pErr);
 
 }
 
@@ -783,32 +781,32 @@ HB_FUNC( CURL_EASY_SETOPT )
                break;
 #endif
 
-               /* Callback */
+            /* Callback */
 
-               /* These are hidden on the Harbour level: */
-               /* HB_CURLOPT_WRITEFUNCTION */
-               /* HB_CURLOPT_WRITEDATA */
-               /* HB_CURLOPT_READFUNCTION */
-               /* HB_CURLOPT_READDATA */
+            /* These are hidden on the Harbour level: */
+            /* HB_CURLOPT_WRITEFUNCTION */
+            /* HB_CURLOPT_WRITEDATA */
+            /* HB_CURLOPT_READFUNCTION */
+            /* HB_CURLOPT_READDATA */
 #if LIBCURL_VERSION_NUM >= 0x070C03
-               /* HB_CURLOPT_IOCTLFUNCTION */
-               /* HB_CURLOPT_IOCTLDATA */
+            /* HB_CURLOPT_IOCTLFUNCTION */
+            /* HB_CURLOPT_IOCTLDATA */
 #endif
-               /* HB_CURLOPT_SEEKFUNCTION */
-               /* HB_CURLOPT_SEEKDATA */
-               /* HB_CURLOPT_SOCKOPTFUNCTION */
-               /* HB_CURLOPT_SOCKOPTDATA */
-               /* HB_CURLOPT_OPENSOCKETFUNCTION */
-               /* HB_CURLOPT_OPENSOCKETDATA */
-               /* HB_CURLOPT_PROGRESSFUNCTION */
-               /* HB_CURLOPT_PROGRESSDATA */
-               /* HB_CURLOPT_HEADERFUNCTION */
-               /* HB_CURLOPT_HEADERDATA / CURLOPT_WRITEHEADER */
-               /* HB_CURLOPT_DEBUGFUNCTION */
-               /* HB_CURLOPT_DEBUGDATA */
+            /* HB_CURLOPT_SEEKFUNCTION */
+            /* HB_CURLOPT_SEEKDATA */
+            /* HB_CURLOPT_SOCKOPTFUNCTION */
+            /* HB_CURLOPT_SOCKOPTDATA */
+            /* HB_CURLOPT_OPENSOCKETFUNCTION */
+            /* HB_CURLOPT_OPENSOCKETDATA */
+            /* HB_CURLOPT_PROGRESSFUNCTION */
+            /* HB_CURLOPT_PROGRESSDATA */
+            /* HB_CURLOPT_HEADERFUNCTION */
+            /* HB_CURLOPT_HEADERDATA / CURLOPT_WRITEHEADER */
+            /* HB_CURLOPT_DEBUGFUNCTION */
+            /* HB_CURLOPT_DEBUGDATA */
 #if LIBCURL_VERSION_NUM >= 0x070B00
-               /* HB_CURLOPT_SSL_CTX_FUNCTION */
-               /* HB_CURLOPT_SSL_CTX_DATA */
+            /* HB_CURLOPT_SSL_CTX_FUNCTION */
+            /* HB_CURLOPT_SSL_CTX_DATA */
 #endif
             /* HB_CURLOPT_CONV_TO_NETWORK_FUNCTION */
             /* HB_CURLOPT_CONV_FROM_NETWORK_FUNCTION */
@@ -817,20 +815,19 @@ HB_FUNC( CURL_EASY_SETOPT )
             /* Error */
 
             /* HB_CURLOPT_ERRORBUFFER */
+            /* HB_CURLOPT_STDERR */
             case HB_CURLOPT_STDERR:
 
-               if( hb_curl->pErr )
-                  fclose( hb_curl->pErr );
-
+			   if (hb_curl->pErr) 
+			      fclose( hb_curl->pErr);
+               
                if( HB_ISCHAR( 3 ) )
-               {
-                  hb_curl->pErr = hb_fopen( hb_parc( 3 ), "a"  );
-				  
-				  if ( hb_curl->pErr  )
+               {					
+                    hb_curl->pErr = hb_fopen( hb_parc( 3 ), "a"  );
+					
+					/* Warning: passing a file pointer is unsafe. Use at your own risk */
 					res = curl_easy_setopt( hb_curl->curl, CURLOPT_STDERR, hb_curl->pErr );
                }
-
-               break;
 
             case HB_CURLOPT_FAILONERROR:
                res = curl_easy_setopt( hb_curl->curl, CURLOPT_FAILONERROR, HB_CURL_OPT_BOOL( 3 ) );
@@ -1065,7 +1062,7 @@ HB_FUNC( CURL_EASY_SETOPT )
                                    &hb_curl->pHTTPPOST_Last,
                                    CURLFORM_COPYNAME, hb_arrayGetCPtr( pSubArray, 1 ),
                                    CURLFORM_NAMELENGTH, hb_arrayGetCLen( pSubArray, 1 ),
-                                   CURLFORM_COPYCONTENTS, hb_arrayGetCPtr( pSubArray, 2 ),
+								   CURLFORM_COPYCONTENTS, hb_arrayGetCPtr( pSubArray, 2 ),
                                    CURLFORM_CONTENTSLENGTH, hb_arrayGetCLen( pSubArray, 2 ),
                                    CURLFORM_END );
                   }
@@ -1073,7 +1070,7 @@ HB_FUNC( CURL_EASY_SETOPT )
                   res = curl_easy_setopt( hb_curl->curl, CURLOPT_HTTPPOST, hb_curl->pHTTPPOST_First );
                }
             }
-            break;
+            break;			
             case HB_CURLOPT_REFERER:
                res = curl_easy_setopt( hb_curl->curl, CURLOPT_REFERER, hb_curl_StrHash( hb_curl, hb_parc( 3 ) ) );
                break;

--- a/contrib/hbcurl/hbcurl.ch
+++ b/contrib/hbcurl/hbcurl.ch
@@ -267,6 +267,7 @@
 #define HB_CURLOPT_UL_NULL_SETUP              1010
 #define HB_CURLOPT_UL_FHANDLE_SETUP           1011
 #define HB_CURLOPT_DL_FHANDLE_SETUP           1012
+#define HB_CURLOPT_HTTPPOST_VALUE             1013
 /* Compatibility ones. Please don't use these. */
 #define HB_CURLOPT_SETUPLOADFILE              HB_CURLOPT_UL_FILE_SETUP
 #define HB_CURLOPT_CLOSEUPLOADFILE            HB_CURLOPT_UL_FILE_CLOSE

--- a/contrib/hbcurl/hbcurl.ch
+++ b/contrib/hbcurl/hbcurl.ch
@@ -267,7 +267,7 @@
 #define HB_CURLOPT_UL_NULL_SETUP              1010
 #define HB_CURLOPT_UL_FHANDLE_SETUP           1011
 #define HB_CURLOPT_DL_FHANDLE_SETUP           1012
-#define HB_CURLOPT_HTTPPOST_VALUE             1013
+#define HB_CURLOPT_HTTPPOST_CONTENT           1013
 /* Compatibility ones. Please don't use these. */
 #define HB_CURLOPT_SETUPLOADFILE              HB_CURLOPT_UL_FILE_SETUP
 #define HB_CURLOPT_CLOSEUPLOADFILE            HB_CURLOPT_UL_FILE_CLOSE

--- a/contrib/hbwin/hbwin.hbp
+++ b/contrib/hbwin/hbwin.hbp
@@ -29,7 +29,7 @@ mapi.c
 oemansi.c
 olecore.c
 oleuuid.c{watcom}
-hbolesrv.c
+{HBWIN_HAS_OLESRV}hbolesrv.c
 wapi_alloc.c
 wapi_commctrl.c
 wapi_err.c

--- a/src/rtl/hbregex.c
+++ b/src/rtl/hbregex.c
@@ -54,13 +54,13 @@
 #include "hbinit.h"
 
 #if defined( HB_HAS_PCRE )
-   static int s_iUTF8Enabled;
+static int s_iUTF8Enabled;
 #endif
 
 static void hb_regfree( PHB_REGEX pRegEx )
 {
 #if defined( HB_HAS_PCRE )
-   ( pcre_free )( pRegEx->re_pcre );
+   ( pcre_free ) ( pRegEx->re_pcre );
 #elif defined( HB_POSIX_REGEX )
    regfree( &pRegEx->reg );
 #else
@@ -72,11 +72,11 @@ static int hb_regcomp( PHB_REGEX pRegEx, const char * szRegEx )
 {
 #if defined( HB_HAS_PCRE )
    const unsigned char * pCharTable = NULL;
-   const char * szError = NULL;
+   const char *          szError    = NULL;
    int iErrOffset = 0;
-   int iCFlags = ( ( pRegEx->iFlags & HBREG_ICASE   ) ? PCRE_CASELESS  : 0 ) |
-                 ( ( pRegEx->iFlags & HBREG_NEWLINE ) ? PCRE_MULTILINE : 0 ) |
-                 ( ( pRegEx->iFlags & HBREG_DOTALL  ) ? PCRE_DOTALL    : 0 );
+   int iCFlags    = ( ( pRegEx->iFlags & HBREG_ICASE ) ? PCRE_CASELESS  : 0 ) |
+                    ( ( pRegEx->iFlags & HBREG_NEWLINE ) ? PCRE_MULTILINE : 0 ) |
+                    ( ( pRegEx->iFlags & HBREG_DOTALL ) ? PCRE_DOTALL    : 0 );
 
    pRegEx->iEFlags = ( ( pRegEx->iFlags & HBREG_NOTBOL ) ? PCRE_NOTBOL : 0 ) |
                      ( ( pRegEx->iFlags & HBREG_NOTEOL ) ? PCRE_NOTEOL : 0 );
@@ -90,9 +90,9 @@ static int hb_regcomp( PHB_REGEX pRegEx, const char * szRegEx )
    return pRegEx->re_pcre ? 0 : -1;
 #elif defined( HB_POSIX_REGEX )
    int iCFlags = REG_EXTENDED |
-                 ( ( pRegEx->iFlags & HBREG_ICASE   ) ? REG_ICASE   : 0 ) |
+                 ( ( pRegEx->iFlags & HBREG_ICASE ) ? REG_ICASE   : 0 ) |
                  ( ( pRegEx->iFlags & HBREG_NEWLINE ) ? REG_NEWLINE : 0 ) |
-                 ( ( pRegEx->iFlags & HBREG_NOSUB   ) ? REG_NOSUB   : 0 );
+                 ( ( pRegEx->iFlags & HBREG_NOSUB ) ? REG_NOSUB   : 0 );
    pRegEx->iEFlags = ( ( pRegEx->iFlags & HBREG_NOTBOL ) ? REG_NOTBOL : 0 ) |
                      ( ( pRegEx->iFlags & HBREG_NOTEOL ) ? REG_NOTEOL : 0 );
    return regcomp( &pRegEx->reg, szRegEx, iCFlags );
@@ -123,7 +123,7 @@ static int hb_regexec( PHB_REGEX pRegEx, const char * szString, HB_SIZE nLen,
    return iResult;
 #elif defined( HB_POSIX_REGEX )
    char * szBuffer = NULL;
-   int iResult, i;
+   int    iResult, i;
 
    if( szString[ nLen ] != 0 )
    {
@@ -165,7 +165,7 @@ HB_FUNC( HB_REGEXCOMP )
       hb_errRT_BASE_SubstR( EG_ARG, 3012, NULL, HB_ERR_FUNCNAME, HB_ERR_ARGS_BASEPARAMS );
    else
    {
-      int iFlags = HBREG_EXTENDED;
+      int       iFlags = HBREG_EXTENDED;
       PHB_REGEX pRegEx;
 
       if( ! hb_parldef( 2, 1 ) )
@@ -198,14 +198,14 @@ HB_FUNC( HB_ATX )
 
       if( pRegEx )
       {
-         HB_SIZE nLen = hb_itemGetCLen( pString );
+         HB_SIZE nLen   = hb_itemGetCLen( pString );
          HB_SIZE nStart = hb_parns( 4 );
-         HB_SIZE nEnd = hb_parnsdef( 5, nLen );
+         HB_SIZE nEnd   = hb_parnsdef( 5, nLen );
 
          if( nLen && nStart <= nLen && nStart <= nEnd )
          {
             const char * pszString = hb_itemGetCPtr( pString );
-            HB_REGMATCH aMatches[ HB_REGMATCH_SIZE( 1 ) ];
+            HB_REGMATCH  aMatches[ HB_REGMATCH_SIZE( 1 ) ];
 
             if( nEnd < nLen )
                nLen = nEnd;
@@ -218,7 +218,7 @@ HB_FUNC( HB_ATX )
             if( hb_regexec( pRegEx, pszString + nStart, nLen, 1, aMatches ) > 0 )
             {
                nStart += HB_REGMATCH_SO( aMatches, 0 ) + 1;
-               nLen = HB_REGMATCH_EO( aMatches, 0 ) - HB_REGMATCH_SO( aMatches, 0 );
+               nLen    = HB_REGMATCH_EO( aMatches, 0 ) - HB_REGMATCH_SO( aMatches, 0 );
                hb_retclen( pszString + nStart - 1, nLen );
             }
             else
@@ -244,13 +244,13 @@ HB_FUNC( HB_ATX )
 
 static HB_BOOL hb_regex( int iRequest )
 {
-   HB_REGMATCH aMatches[ HB_REGMATCH_SIZE( REGEX_MAX_GROUPS ) ];
-   PHB_ITEM pRetArray, pMatch, pString;
-   int i, iMatches, iMaxMatch;
-   HB_BOOL fResult = HB_FALSE;
-   PHB_REGEX pRegEx;
+   HB_REGMATCH  aMatches[ HB_REGMATCH_SIZE( REGEX_MAX_GROUPS ) ];
+   PHB_ITEM     pRetArray, pMatch, pString;
+   int          i, iMatches, iMaxMatch;
+   HB_BOOL      fResult = HB_FALSE;
+   PHB_REGEX    pRegEx;
    const char * pszString;
-   HB_SIZE nLen;
+   HB_SIZE      nLen;
 
    pString = hb_param( 2, HB_IT_STRING );
    if( ! pString )
@@ -258,9 +258,11 @@ static HB_BOOL hb_regex( int iRequest )
       hb_errRT_BASE_SubstR( EG_ARG, 3014, NULL, HB_ERR_FUNCNAME, HB_ERR_ARGS_BASEPARAMS );
       return HB_FALSE;
    }
+
    pRegEx = hb_regexGet( hb_param( 1, HB_IT_ANY ),
                          ( ! hb_parldef( 3, 1 ) ? HBREG_ICASE : 0 ) |
-                         ( hb_parl( 4 ) ? HBREG_NEWLINE : 0 ) );
+                         ( hb_parl( 4 ) ? HBREG_NEWLINE : 0 ) |
+                         ( hb_parl( 8 ) ? HBREG_DOTALL : 0 ) );
    if( ! pRegEx )
       return HB_FALSE;
 
@@ -301,13 +303,13 @@ static HB_BOOL hb_regex( int iRequest )
          case 3: /* SPLIT */
             iMaxMatch = hb_parni( 5 );
             pRetArray = hb_itemArrayNew( 0 );
-            pMatch = hb_itemNew( NULL );
-            iMatches = 0;
+            pMatch    = hb_itemNew( NULL );
+            iMatches  = 0;
             do
             {
                hb_itemPutCL( pMatch, pszString, HB_REGMATCH_SO( aMatches, 0 ) );
                hb_arrayAddForward( pRetArray, pMatch );
-               nLen -= HB_REGMATCH_EO( aMatches, 0 );
+               nLen      -= HB_REGMATCH_EO( aMatches, 0 );
                pszString += HB_REGMATCH_EO( aMatches, 0 );
                iMatches++;
             }
@@ -360,8 +362,8 @@ static HB_BOOL hb_regex( int iRequest )
          case 5: /* _ALL_ results AND positions */
          {
             PHB_ITEM pAtxArray;
-            int      iMax       = hb_parni( 5 );   /* max nuber of matches I want, 0 = unlimited */
-            int      iGetMatch  = hb_parni( 6 );   /* Gets if want only one single match or a sub-match */
+            int      iMax       = hb_parni( 5 );      /* max nuber of matches I want, 0 = unlimited */
+            int      iGetMatch  = hb_parni( 6 );      /* Gets if want only one single match or a sub-match */
             HB_BOOL  fOnlyMatch = hb_parldef( 7, 1 ); /* if HB_TRUE returns only matches and sub-matches, not positions */
             HB_SIZE  nOffset    = 0;
             int      iCount     = 0;
@@ -378,8 +380,8 @@ static HB_BOOL hb_regex( int iRequest )
                   pAtxArray = hb_itemArrayNew( iMatches );
                   for( i = 0; i < iMatches; i++ )
                   {
-                     iSO = HB_REGMATCH_SO( aMatches, i );
-                     iEO = HB_REGMATCH_EO( aMatches, i );
+                     iSO    = HB_REGMATCH_SO( aMatches, i );
+                     iEO    = HB_REGMATCH_EO( aMatches, i );
                      pMatch = hb_arrayGetItemPtr( pAtxArray, i + 1 );
                      if( ! fOnlyMatch )
                      {
@@ -414,9 +416,9 @@ static HB_BOOL hb_regex( int iRequest )
                }
                else /* Here I get only single matches */
                {
-                  i = iGetMatch - 1;
-                  iSO = HB_REGMATCH_SO( aMatches, i );
-                  iEO = HB_REGMATCH_EO( aMatches, i );
+                  i      = iGetMatch - 1;
+                  iSO    = HB_REGMATCH_SO( aMatches, i );
+                  iEO    = HB_REGMATCH_EO( aMatches, i );
                   pMatch = hb_itemNew( NULL );
                   if( ! fOnlyMatch )
                   {
@@ -452,9 +454,9 @@ static HB_BOOL hb_regex( int iRequest )
                iEO = HB_REGMATCH_EO( aMatches, 0 );
                if( iEO == -1 )
                   break;
-               nLen -= iEO;
+               nLen      -= iEO;
                pszString += iEO;
-               nOffset += iEO;
+               nOffset   += iEO;
                iCount++;
             }
             while( iEO && nLen && ( iMax == 0 || iCount < iMax ) &&
@@ -556,24 +558,24 @@ static void hb_pcre_free( void * ptr )
 
 HB_CALL_ON_STARTUP_BEGIN( _hb_regex_init_ )
 #if defined( HB_HAS_PCRE )
-   /* detect UTF-8 support.
-    * In BCC builds this code also forces linking newer PCRE versions
-    * then the one included in BCC RTL.
-    */
-   if( pcre_config( PCRE_CONFIG_UTF8, &s_iUTF8Enabled ) != 0 )
-      s_iUTF8Enabled = 0;
+/* detect UTF-8 support.
+ * In BCC builds this code also forces linking newer PCRE versions
+ * then the one included in BCC RTL.
+ */
+if( pcre_config( PCRE_CONFIG_UTF8, &s_iUTF8Enabled ) != 0 )
+   s_iUTF8Enabled = 0;
 
-   pcre_malloc = hb_pcre_grab;
-   pcre_free = hb_pcre_free;
-   pcre_stack_malloc = hb_pcre_grab;
-   pcre_stack_free = hb_pcre_free;
+pcre_malloc       = hb_pcre_grab;
+pcre_free         = hb_pcre_free;
+pcre_stack_malloc = hb_pcre_grab;
+pcre_stack_free   = hb_pcre_free;
 #endif
-   hb_regexInit( hb_regfree, hb_regcomp, hb_regexec );
+hb_regexInit( hb_regfree, hb_regcomp, hb_regexec );
 HB_CALL_ON_STARTUP_END( _hb_regex_init_ )
 
 #if defined( HB_PRAGMA_STARTUP )
    #pragma startup _hb_regex_init_
 #elif defined( HB_DATASEG_STARTUP )
-   #define HB_DATASEG_BODY    HB_DATASEG_FUNC( _hb_regex_init_ )
+   #define HB_DATASEG_BODY  HB_DATASEG_FUNC( _hb_regex_init_ )
    #include "hbiniseg.h"
 #endif

--- a/src/rtl/hbregex.c
+++ b/src/rtl/hbregex.c
@@ -54,13 +54,13 @@
 #include "hbinit.h"
 
 #if defined( HB_HAS_PCRE )
-static int s_iUTF8Enabled;
+   static int s_iUTF8Enabled;
 #endif
 
 static void hb_regfree( PHB_REGEX pRegEx )
 {
 #if defined( HB_HAS_PCRE )
-   ( pcre_free ) ( pRegEx->re_pcre );
+   ( pcre_free )( pRegEx->re_pcre );
 #elif defined( HB_POSIX_REGEX )
    regfree( &pRegEx->reg );
 #else
@@ -72,11 +72,11 @@ static int hb_regcomp( PHB_REGEX pRegEx, const char * szRegEx )
 {
 #if defined( HB_HAS_PCRE )
    const unsigned char * pCharTable = NULL;
-   const char *          szError    = NULL;
+   const char * szError = NULL;
    int iErrOffset = 0;
-   int iCFlags    = ( ( pRegEx->iFlags & HBREG_ICASE ) ? PCRE_CASELESS  : 0 ) |
-                    ( ( pRegEx->iFlags & HBREG_NEWLINE ) ? PCRE_MULTILINE : 0 ) |
-                    ( ( pRegEx->iFlags & HBREG_DOTALL ) ? PCRE_DOTALL    : 0 );
+   int iCFlags = ( ( pRegEx->iFlags & HBREG_ICASE   ) ? PCRE_CASELESS  : 0 ) |
+                 ( ( pRegEx->iFlags & HBREG_NEWLINE ) ? PCRE_MULTILINE : 0 ) |
+                 ( ( pRegEx->iFlags & HBREG_DOTALL  ) ? PCRE_DOTALL    : 0 );
 
    pRegEx->iEFlags = ( ( pRegEx->iFlags & HBREG_NOTBOL ) ? PCRE_NOTBOL : 0 ) |
                      ( ( pRegEx->iFlags & HBREG_NOTEOL ) ? PCRE_NOTEOL : 0 );
@@ -90,9 +90,9 @@ static int hb_regcomp( PHB_REGEX pRegEx, const char * szRegEx )
    return pRegEx->re_pcre ? 0 : -1;
 #elif defined( HB_POSIX_REGEX )
    int iCFlags = REG_EXTENDED |
-                 ( ( pRegEx->iFlags & HBREG_ICASE ) ? REG_ICASE   : 0 ) |
+                 ( ( pRegEx->iFlags & HBREG_ICASE   ) ? REG_ICASE   : 0 ) |
                  ( ( pRegEx->iFlags & HBREG_NEWLINE ) ? REG_NEWLINE : 0 ) |
-                 ( ( pRegEx->iFlags & HBREG_NOSUB ) ? REG_NOSUB   : 0 );
+                 ( ( pRegEx->iFlags & HBREG_NOSUB   ) ? REG_NOSUB   : 0 );
    pRegEx->iEFlags = ( ( pRegEx->iFlags & HBREG_NOTBOL ) ? REG_NOTBOL : 0 ) |
                      ( ( pRegEx->iFlags & HBREG_NOTEOL ) ? REG_NOTEOL : 0 );
    return regcomp( &pRegEx->reg, szRegEx, iCFlags );
@@ -123,7 +123,7 @@ static int hb_regexec( PHB_REGEX pRegEx, const char * szString, HB_SIZE nLen,
    return iResult;
 #elif defined( HB_POSIX_REGEX )
    char * szBuffer = NULL;
-   int    iResult, i;
+   int iResult, i;
 
    if( szString[ nLen ] != 0 )
    {
@@ -165,7 +165,7 @@ HB_FUNC( HB_REGEXCOMP )
       hb_errRT_BASE_SubstR( EG_ARG, 3012, NULL, HB_ERR_FUNCNAME, HB_ERR_ARGS_BASEPARAMS );
    else
    {
-      int       iFlags = HBREG_EXTENDED;
+      int iFlags = HBREG_EXTENDED;
       PHB_REGEX pRegEx;
 
       if( ! hb_parldef( 2, 1 ) )
@@ -198,14 +198,14 @@ HB_FUNC( HB_ATX )
 
       if( pRegEx )
       {
-         HB_SIZE nLen   = hb_itemGetCLen( pString );
+         HB_SIZE nLen = hb_itemGetCLen( pString );
          HB_SIZE nStart = hb_parns( 4 );
-         HB_SIZE nEnd   = hb_parnsdef( 5, nLen );
+         HB_SIZE nEnd = hb_parnsdef( 5, nLen );
 
          if( nLen && nStart <= nLen && nStart <= nEnd )
          {
             const char * pszString = hb_itemGetCPtr( pString );
-            HB_REGMATCH  aMatches[ HB_REGMATCH_SIZE( 1 ) ];
+            HB_REGMATCH aMatches[ HB_REGMATCH_SIZE( 1 ) ];
 
             if( nEnd < nLen )
                nLen = nEnd;
@@ -218,7 +218,7 @@ HB_FUNC( HB_ATX )
             if( hb_regexec( pRegEx, pszString + nStart, nLen, 1, aMatches ) > 0 )
             {
                nStart += HB_REGMATCH_SO( aMatches, 0 ) + 1;
-               nLen    = HB_REGMATCH_EO( aMatches, 0 ) - HB_REGMATCH_SO( aMatches, 0 );
+               nLen = HB_REGMATCH_EO( aMatches, 0 ) - HB_REGMATCH_SO( aMatches, 0 );
                hb_retclen( pszString + nStart - 1, nLen );
             }
             else
@@ -244,13 +244,13 @@ HB_FUNC( HB_ATX )
 
 static HB_BOOL hb_regex( int iRequest )
 {
-   HB_REGMATCH  aMatches[ HB_REGMATCH_SIZE( REGEX_MAX_GROUPS ) ];
-   PHB_ITEM     pRetArray, pMatch, pString;
-   int          i, iMatches, iMaxMatch;
-   HB_BOOL      fResult = HB_FALSE;
-   PHB_REGEX    pRegEx;
+   HB_REGMATCH aMatches[ HB_REGMATCH_SIZE( REGEX_MAX_GROUPS ) ];
+   PHB_ITEM pRetArray, pMatch, pString;
+   int i, iMatches, iMaxMatch;
+   HB_BOOL fResult = HB_FALSE;
+   PHB_REGEX pRegEx;
    const char * pszString;
-   HB_SIZE      nLen;
+   HB_SIZE nLen;
 
    pString = hb_param( 2, HB_IT_STRING );
    if( ! pString )
@@ -258,11 +258,11 @@ static HB_BOOL hb_regex( int iRequest )
       hb_errRT_BASE_SubstR( EG_ARG, 3014, NULL, HB_ERR_FUNCNAME, HB_ERR_ARGS_BASEPARAMS );
       return HB_FALSE;
    }
-
-   pRegEx = hb_regexGet( hb_param( 1, HB_IT_ANY ),
-                         ( ! hb_parldef( 3, 1 ) ? HBREG_ICASE : 0 ) |
+    pRegEx = hb_regexGet( hb_param( 1, HB_IT_ANY ),
+                         ( !hb_parldef( 3, 1 ) ? HBREG_ICASE : 0 ) |
                          ( hb_parl( 4 ) ? HBREG_NEWLINE : 0 ) |
-                         ( hb_parl( 8 ) ? HBREG_DOTALL : 0 ) );
+						 ( hb_parl( 8 ) ? HBREG_DOTALL : 0 ) );
+
    if( ! pRegEx )
       return HB_FALSE;
 
@@ -303,13 +303,13 @@ static HB_BOOL hb_regex( int iRequest )
          case 3: /* SPLIT */
             iMaxMatch = hb_parni( 5 );
             pRetArray = hb_itemArrayNew( 0 );
-            pMatch    = hb_itemNew( NULL );
-            iMatches  = 0;
+            pMatch = hb_itemNew( NULL );
+            iMatches = 0;
             do
             {
                hb_itemPutCL( pMatch, pszString, HB_REGMATCH_SO( aMatches, 0 ) );
                hb_arrayAddForward( pRetArray, pMatch );
-               nLen      -= HB_REGMATCH_EO( aMatches, 0 );
+               nLen -= HB_REGMATCH_EO( aMatches, 0 );
                pszString += HB_REGMATCH_EO( aMatches, 0 );
                iMatches++;
             }
@@ -362,8 +362,8 @@ static HB_BOOL hb_regex( int iRequest )
          case 5: /* _ALL_ results AND positions */
          {
             PHB_ITEM pAtxArray;
-            int      iMax       = hb_parni( 5 );      /* max nuber of matches I want, 0 = unlimited */
-            int      iGetMatch  = hb_parni( 6 );      /* Gets if want only one single match or a sub-match */
+            int      iMax       = hb_parni( 5 );   /* max nuber of matches I want, 0 = unlimited */
+            int      iGetMatch  = hb_parni( 6 );   /* Gets if want only one single match or a sub-match */
             HB_BOOL  fOnlyMatch = hb_parldef( 7, 1 ); /* if HB_TRUE returns only matches and sub-matches, not positions */
             HB_SIZE  nOffset    = 0;
             int      iCount     = 0;
@@ -380,8 +380,8 @@ static HB_BOOL hb_regex( int iRequest )
                   pAtxArray = hb_itemArrayNew( iMatches );
                   for( i = 0; i < iMatches; i++ )
                   {
-                     iSO    = HB_REGMATCH_SO( aMatches, i );
-                     iEO    = HB_REGMATCH_EO( aMatches, i );
+                     iSO = HB_REGMATCH_SO( aMatches, i );
+                     iEO = HB_REGMATCH_EO( aMatches, i );
                      pMatch = hb_arrayGetItemPtr( pAtxArray, i + 1 );
                      if( ! fOnlyMatch )
                      {
@@ -416,9 +416,9 @@ static HB_BOOL hb_regex( int iRequest )
                }
                else /* Here I get only single matches */
                {
-                  i      = iGetMatch - 1;
-                  iSO    = HB_REGMATCH_SO( aMatches, i );
-                  iEO    = HB_REGMATCH_EO( aMatches, i );
+                  i = iGetMatch - 1;
+                  iSO = HB_REGMATCH_SO( aMatches, i );
+                  iEO = HB_REGMATCH_EO( aMatches, i );
                   pMatch = hb_itemNew( NULL );
                   if( ! fOnlyMatch )
                   {
@@ -454,9 +454,9 @@ static HB_BOOL hb_regex( int iRequest )
                iEO = HB_REGMATCH_EO( aMatches, 0 );
                if( iEO == -1 )
                   break;
-               nLen      -= iEO;
+               nLen -= iEO;
                pszString += iEO;
-               nOffset   += iEO;
+               nOffset += iEO;
                iCount++;
             }
             while( iEO && nLen && ( iMax == 0 || iCount < iMax ) &&
@@ -558,24 +558,24 @@ static void hb_pcre_free( void * ptr )
 
 HB_CALL_ON_STARTUP_BEGIN( _hb_regex_init_ )
 #if defined( HB_HAS_PCRE )
-/* detect UTF-8 support.
- * In BCC builds this code also forces linking newer PCRE versions
- * then the one included in BCC RTL.
- */
-if( pcre_config( PCRE_CONFIG_UTF8, &s_iUTF8Enabled ) != 0 )
-   s_iUTF8Enabled = 0;
+   /* detect UTF-8 support.
+    * In BCC builds this code also forces linking newer PCRE versions
+    * then the one included in BCC RTL.
+    */
+   if( pcre_config( PCRE_CONFIG_UTF8, &s_iUTF8Enabled ) != 0 )
+      s_iUTF8Enabled = 0;
 
-pcre_malloc       = hb_pcre_grab;
-pcre_free         = hb_pcre_free;
-pcre_stack_malloc = hb_pcre_grab;
-pcre_stack_free   = hb_pcre_free;
+   pcre_malloc = hb_pcre_grab;
+   pcre_free = hb_pcre_free;
+   pcre_stack_malloc = hb_pcre_grab;
+   pcre_stack_free = hb_pcre_free;
 #endif
-hb_regexInit( hb_regfree, hb_regcomp, hb_regexec );
+   hb_regexInit( hb_regfree, hb_regcomp, hb_regexec );
 HB_CALL_ON_STARTUP_END( _hb_regex_init_ )
 
 #if defined( HB_PRAGMA_STARTUP )
    #pragma startup _hb_regex_init_
 #elif defined( HB_DATASEG_STARTUP )
-   #define HB_DATASEG_BODY  HB_DATASEG_FUNC( _hb_regex_init_ )
+   #define HB_DATASEG_BODY    HB_DATASEG_FUNC( _hb_regex_init_ )
    #include "hbiniseg.h"
 #endif


### PR DESCRIPTION

hbcurl:      

  HB_CURLOPT_STDERR - implemented verbose log to a chosen file
  added HB_CURLOPT_HTTPPOST_VALUE: like HB_CURLOPT_HTTPPOST but using values instead of files

hbregex.c: added missing HBREG_DOTALL functionality

hbwin.hbp : workaround : hb ole server opt in to prevent clashes when using  static library in a dll