### PR TITLE
fixed position of cursor in F6-WA window

### DIFF
--- a/src/debug/dbgwa.prg
+++ b/src/debug/dbgwa.prg
@@ -160,6 +160,8 @@ PROCEDURE __dbgShowWorkAreas()
 
 STATIC PROCEDURE DlgWorkAreaPaint( oDlg, aBrw )
 
+   LOCAL oDebug := __dbg()
+
    /* Display captions */
 
    hb_DispOutAt( oDlg:nTop, oDlg:nLeft + 5, " Area ", oDlg:cColor )
@@ -193,8 +195,7 @@ STATIC PROCEDURE DlgWorkAreaPaint( oDlg, aBrw )
    aBrw[ 1 ]:ForceStable()
    aBrw[ 2 ]:ForceStable()
    aBrw[ 3 ]:ForceStable()
-   aBrw[ 2 ]:Dehilite()
-   aBrw[ 3 ]:Dehilite()
+   aEval( aBrw, {| a, i | iif( oDebug:nWaFocus == i, a:HiLite(), a:DeHilite() ) } )
 
    UpdateInfo( oDlg, Alias() )
 


### PR DESCRIPTION
Hi!
Can anyone review my patch to fix position of cursor in F6-WA window?
To reproduce wrong behavior do the next steps:
Altd(), F6, Tab (cursor in 'status'), Esc, F6 (real cursor in 'status', but dehilite, hilite in 'area').

Regards.