### PR TITLE
Error to build harbour with bcc <= 5.8.2

### DIFF
--- a/contrib/hbexpat/3rd/expat/xmltok.c
+++ b/contrib/hbexpat/3rd/expat/xmltok.c
@@ -33,7 +33,7 @@
 #include <stddef.h>
 #include <string.h>  /* memcpy */
 
-#if defined(_MSC_VER) && (_MSC_VER <= 1700)
+#if ( defined(_MSC_VER) && (_MSC_VER <= 1700) ) || ( defined( __BORLANDC__ ) && __BORLANDC__ <= 0x582 )
   /* for vs2012/11.0/1700 and earlier Visual Studio compilers */
 # define bool   int
 # define false  0

--- a/src/compiler/hbusage.c
+++ b/src/compiler/hbusage.c
@@ -209,6 +209,7 @@ void hb_compPrintCredits( HB_COMP_DECL )
          "Jose Lalin (dezac corevia.com)\n"
          "Klas Engwall (harbour engwall.com)\n"
          "Kwon, Oh-Chul (ohchul fivetech.net)\n"
+         "Lailton Fernando Mariano (lailton harbour.com.br)\n"
          "Leslee Griffith (les.griffith vantagesystems.ca)\n"
          "Lorenzo Fiorini (lorenzo.fiorini gmail com)\n"
          "Luis Krause Mantilla (lkrausem shaw.ca)\n"


### PR DESCRIPTION
Fixed error to build harbour with BCC 5.8.2

Borland Implib Version 3.0.22 Copyright (c) 1991, 2000 Inprise Corporation
D:\harbour\bin\win\bcc\hbmk2 -quiet -width=0 -autohbm- @hbpre -inc hbexpat/3rd/e
xpat/expat.hbp @hbpost
hbexpat\3rd\expat\loadlibr.c:
hbexpat\3rd\expat\xmlparse.c:
hbexpat\3rd\expat\xmlrole.c:
hbexpat\3rd\expat\xmltok.c:
Error E2451 hbexpat\3rd\expat\xmltok.c 403: Undefined symbol '_Bool' in function
utf8_toUtf8
Error E2379 hbexpat\3rd\expat\xmltok.c 403: Statement missing ; in function utf8
_toUtf8
Error E2379 hbexpat\3rd\expat\xmltok.c 404: Statement missing ; in function utf8
_toUtf8
Error E2140 hbexpat\3rd\expat\xmltok.c 407: Declaration is not allowed here in f
unction utf8_toUtf8
Error E2140 hbexpat\3rd\expat\xmltok.c 408: Declaration is not allowed here in f
unction utf8_toUtf8
Error E2451 hbexpat\3rd\expat\xmltok.c 411: Undefined symbol 'output_exhausted'
in function utf8_toUtf8
Error E2451 hbexpat\3rd\expat\xmltok.c 419: Undefined symbol 'input_incomplete'
in function utf8_toUtf8
Error E2451 hbexpat\3rd\expat\xmltok.c 430: Undefined symbol 'output_exhausted'
in function utf8_toUtf8
Error E2451 hbexpat\3rd\expat\xmltok.c 432: Undefined symbol 'input_incomplete'
in function utf8_toUtf8
*** 9 errors in Compile ***
hbmk2[expat]: Error: Running C/C++ compiler. 1
hbmk2[expat]: Exit status: 6: failed in compilation (Harbour, C compiler, Resour
ce compiler)
! Finished package build...
makefile:8: recipe for target 'first' failed
win-make.exe[1]: *** [first] Error 6
config/dir.mk:71: recipe for target 'contrib' failed
win-make.exe: *** [contrib] Error 2