### PR TITLE
Better checking for _SYS_SYSCTL_H_

### DIFF
--- a/src/rtl/arc4.c
+++ b/src/rtl/arc4.c
@@ -50,7 +50,9 @@
 /* XXX: Check and possibly extend this to other Unix-like platforms */
 #if ( defined( HB_OS_BSD ) && ! defined( HB_OS_DARWIN ) ) || \
    ( defined( HB_OS_LINUX ) && ! defined ( HB_OS_ANDROID ) && ! defined ( __WATCOMC__ ) )
-#  define HAVE_SYS_SYSCTL_H
+#  if ( defined ( _SYS_SYSCTL_H_ ) )
+#     define HAVE_SYS_SYSCTL_H
+#  endif
 #  define HAVE_DECL_CTL_KERN
 #  define HAVE_DECL_KERN_RANDOM
 #  if defined( HB_OS_LINUX )


### PR DESCRIPTION
This change checks if sys/sysctl.h has been properly loaded (_SYS_SYSCTL_H_should be defined).
Builds on Alpine Linux are failing because of that. This merge also fixes one problem from  #176 issue.