### PR TITLE
Update tgetlist.prg

### DIFF
--- a/src/rtl/tgetlist.prg
+++ b/src/rtl/tgetlist.prg
@@ -864,7 +864,7 @@ METHOD GUIReader( oGet, oMenu, aMsg ) CLASS HBGetList
          CASE ::nHitCode == HTCAPTION
             oGUI:Select()
          CASE ::nHitCode == HTCLIENT
-            oGUI:Select( K_LBUTTONDOWN )
+            oGUI:Select()
          CASE ::nHitCode == HTDROPBUTTON
             oGUI:Open()
          CASE ::nHitCode >= HTSCROLLFIRST .AND. ;


### PR DESCRIPTION
Removed reference to  K_LBUTTONDOWN  to avoid the weird problem of the 1002nd item of a long list in GET LISTBOX DROPDOWN
To test just use it with an array of more than 1000 items
I really do not know for what it was there ( K_LBUTTONDOWN ) but removing it will cause the code to work properly.

Note: To test you need to use something like GTWVT/WVG and mouse clicks between fields. When you click on a GET LISTBOX field with an array of more than 1000 items you will see the error: It always point to the 1002nd element doesn't matter which one was previously selected on the GET variable.
To see the problem you just need to go back to the previous GET and go forward to the GET with the LIST. Then you will see that doesn't matter which one you had previously selected it will always point to the 1002nd item 

Build the following test with hbmk2 -gtwvt option:

#include 'inkey.ch'

ANNOUNCE HB_GTSYS
REQUEST  HB_GT_WVT_DEFAULT

REQUEST HB_CODEPAGE_FRISO


PROCEDURE MAIN()

   LOCAL i
   LOCAL aList := {}
   LOCAL c1 := 'test'
   LOCAL c2 := '1000'


   hb_cdpSelect( 'FRISO' )

   SET EVENTMASK TO INKEY_ALL + HB_INKEY_GTEVENT - INKEY_MOVE

   FOR i := 1 TO 1030
      AADD( aList, { STRZERO(i,4) + '-xxxxx', STRZERO(i,4) } )
   NEXT i
     
   DO WHILE .T.
      CLS

      @ 6,0 GET c1
      @ 8,0,23,50 GET c2 LISTBOX aList DROPDOWN SCROLLBAR
      
      READ

      IF LASTKEY() == K_ESC
         EXIT
      ENDIF

   ENDDO

RETURN
 