### PR TITLE
2022-05-02 08:38 UTC+0200 Antonino Perricone

### DIFF
--- a/contrib/hbcurl/core.c
+++ b/contrib/hbcurl/core.c
@@ -115,6 +115,7 @@ typedef struct _HB_CURL
    size_t          dl_pos;
 
    PHB_ITEM pProgressCallback;
+   PHB_ITEM pDebugCallback;
 
    PHB_HASH_TABLE pHash;
 
@@ -407,6 +408,30 @@ static int hb_curl_progress_callback( void * Cargo, double dltotal, double dlnow
    return 0;
 }
 
+static int hb_curl_debug_callback(CURL *handle, curl_infotype type, char *data, size_t size, void *Cargo)
+{
+   HB_SYMBOL_UNUSED( handle );
+   if( Cargo )
+   {
+      PHB_CURL hb_curl = ( PHB_CURL ) Cargo;
+      if( hb_vmRequestReenter() )
+      {
+         hb_vmPushEvalSym();
+         hb_vmPush( hb_curl->pDebugCallback );
+         hb_vmPushInteger( type );
+         hb_vmPushString( data, size);
+         hb_vmSend( 2 );
+
+         //if( hb_parl( -1 ) )
+         //   return 1;  /* Abort */
+
+         hb_vmRequestRestore();
+      }
+   }
+
+   return 0;
+}
+
 /* Helpers */
 /* ------- */
 
@@ -527,6 +552,12 @@ static void PHB_CURL_free( PHB_CURL hb_curl, HB_BOOL bFree )
       hb_curl->pProgressCallback = NULL;
    }
 
+   if( hb_curl->pDebugCallback )
+   {
+      hb_itemRelease( hb_curl->pDebugCallback );
+      hb_curl->pDebugCallback = NULL;
+   }
+
    if( hb_curl->pHash )
    {
       hb_hashTableKill( hb_curl->pHash );
@@ -587,6 +618,10 @@ static HB_GARBAGE_FUNC( PHB_CURL_mark )
 
       if( hb_curl->pProgressCallback )
          hb_gcMark( hb_curl->pProgressCallback );
+
+      if( hb_curl->pDebugCallback )
+         hb_gcMark( hb_curl->pDebugCallback );
+
    }
 }
 
@@ -1752,6 +1787,33 @@ HB_FUNC( CURL_EASY_SETOPT )
                curl_easy_setopt( hb_curl->curl, CURLOPT_READFUNCTION, hb_curl_read_dummy_callback );
                res = curl_easy_setopt( hb_curl->curl, CURLOPT_READDATA, hb_curl );
                break;
+
+            case HB_CURLOPT_DEBUGBLOCK:
+            {
+               PHB_ITEM pDebugCallback = hb_param( 3, HB_IT_BLOCK | HB_IT_SYMBOL );
+
+               if( hb_curl->pDebugCallback )
+               {
+                  curl_easy_setopt( hb_curl->curl, CURLOPT_DEBUGFUNCTION, NULL );
+                  curl_easy_setopt( hb_curl->curl, CURLOPT_DEBUGDATA, NULL );
+
+                  hb_itemRelease( hb_curl->pDebugCallback );
+                  hb_curl->pDebugCallback = NULL;
+               }
+
+               if( pDebugCallback )
+               {
+                  hb_curl->pDebugCallback = hb_itemNew( pDebugCallback );
+                  /* unlock the item so GC will not mark them as used */
+                  hb_gcUnlock( hb_curl->pDebugCallback );
+
+                  curl_easy_setopt( hb_curl->curl, CURLOPT_DEBUGFUNCTION, hb_curl_debug_callback );
+                  res = curl_easy_setopt( hb_curl->curl, CURLOPT_DEBUGDATA, hb_curl);
+               }
+            }
+            break;
+
+
          }
       }
 

--- a/contrib/hbcurl/core.c
+++ b/contrib/hbcurl/core.c
@@ -414,16 +414,13 @@ static int hb_curl_debug_callback(CURL *handle, curl_infotype type, char *data, 
    if( Cargo )
    {
       PHB_CURL hb_curl = ( PHB_CURL ) Cargo;
-      if( hb_vmRequestReenter() )
+      if( hb_curl->pDebugCallback && hb_vmRequestReenter() )
       {
          hb_vmPushEvalSym();
          hb_vmPush( hb_curl->pDebugCallback );
          hb_vmPushInteger( type );
-         hb_vmPushString( data, size);
+         hb_vmPushStringPcode( data, size);
          hb_vmSend( 2 );
-
-         //if( hb_parl( -1 ) )
-         //   return 1;  /* Abort */
 
          hb_vmRequestRestore();
       }
@@ -1813,6 +1810,9 @@ HB_FUNC( CURL_EASY_SETOPT )
             }
             break;
 
+            case HB_CURLOPT_MAXLIFETIME_CONN:
+               res = curl_easy_setopt( hb_curl->curl, CURLOPT_MAXLIFETIME_CONN, hb_parnl( 3 ) );
+               break;
 
          }
       }

--- a/contrib/hbcurl/hbcurl.ch
+++ b/contrib/hbcurl/hbcurl.ch
@@ -265,6 +265,7 @@
 #define HB_CURLOPT_UL_NULL_SETUP              1010
 #define HB_CURLOPT_UL_FHANDLE_SETUP           1011
 #define HB_CURLOPT_DL_FHANDLE_SETUP           1012
+#define HB_CURLOPT_DEBUGBLOCK                 1013
 /* Compatibility ones. Please don't use these. */
 #define HB_CURLOPT_SETUPLOADFILE              HB_CURLOPT_UL_FILE_SETUP
 #define HB_CURLOPT_CLOSEUPLOADFILE            HB_CURLOPT_UL_FILE_CLOSE
@@ -555,5 +556,16 @@
 #define HB_CURLE_RTSP_SESSION_ERROR           86 /* mismatch of RTSP Session Identifiers */
 #define HB_CURLE_FTP_BAD_FILE_LIST            87 /* unable to parse FTP file list */
 #define HB_CURLE_CHUNK_FAILED                 88 /* chunk callback reported error */
+
+/* curl info . */
+
+#define HB_CURLINFOTYPE_TEXT                  0 /* The data is informational text. */
+#define HB_CURLINFOTYPE_HEADER_IN             1 /* The data is header (or header-like) data received from the peer. */
+#define HB_CURLINFOTYPE_HEADER_OUT            2 /* The data is header (or header-like) data sent to the peer. */
+#define HB_CURLINFOTYPE_DATA_IN               3 /* The data is protocol data received from the peer. */
+#define HB_CURLINFOTYPE_DATA_OUT              4 /* The data is protocol data sent to the peer. */
+#define HB_CURLINFOTYPE_SSL_DATA_IN           5 /* The data is SSL/TLS (binary) data received from the peer. */
+#define HB_CURLINFOTYPE_SSL_DATA_OUT          6 /* The data is SSL/TLS (binary) data sent to the peer. */
+#define HB_CURLINFOTYPE_END                   7 /* */
 
 #endif /* HBCURL_CH_ */

--- a/contrib/hbcurl/hbcurl.ch
+++ b/contrib/hbcurl/hbcurl.ch
@@ -253,6 +253,7 @@
 #define HB_CURLOPT_TCP_KEEPIDLE               205
 #define HB_CURLOPT_TCP_KEEPINTVL              206
 #define HB_CURLOPT_MAIL_AUTH                  207
+#define HB_CURLOPT_MAXLIFETIME_CONN           208
 #define HB_CURLOPT_DOWNLOAD                   1001  /* Harbour special ones */
 #define HB_CURLOPT_PROGRESSBLOCK              1002
 #define HB_CURLOPT_UL_FILE_SETUP              1003


### PR DESCRIPTION
  * contrib\hbcurl\core.c
    + added HB_CURLOPT_DEBUGBLOCK to setup a block for debug information
	  It takes a callback in the form of {|type, msg| ... }
	  see https://curl.se/libcurl/c/CURLOPT_DEBUGFUNCTION.html for more
	  information.
  * contrib\hbcurl\hbcurl.ch
    + added HB_CURLINFOTYPE_* macros for debug block