### PR TITLE
remove -flat_namespace flag on macOS

### DIFF
--- a/config/darwin/global.mk
+++ b/config/darwin/global.mk
@@ -22,7 +22,7 @@ AR_RULE = ( $(AR) -static \
 
 DY_OUT := -o$(subst x,x, )
 
-DY_RULE = $(DY) -dynamiclib -flat_namespace $(DFLAGS) \
+DY_RULE = $(DY) -dynamiclib $(DFLAGS) \
    -install_name "$(DYN_NAME_NVR)" \
    -compatibility_version $(HB_VER_MAJOR).$(HB_VER_MINOR) \
    -current_version $(HB_VER_MAJOR).$(HB_VER_MINOR).$(HB_VER_RELEASE) \

--- a/utils/hbmk2/hbmk2.prg
+++ b/utils/hbmk2/hbmk2.prg
@@ -4123,7 +4123,7 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
          AAddNotEmpty( hbmk[ _HBMK_aOPTCPPX ], gcc_opt_lngcpp_fill( hbmk ) )
          cBin_Dyn := cBin_CompC
          IF hbmk[ _HBMK_cPLAT ] == "darwin"
-            cOpt_Dyn := "-dynamiclib -o {OD} -flat_namespace -undefined dynamic_lookup {FD} {DL} {LO} {LS}" /* NOTE: -single_module is now the default in ld/libtool. */
+            cOpt_Dyn := "-dynamiclib -o {OD} -undefined dynamic_lookup {FD} {DL} {LO} {LS}" /* NOTE: -single_module is now the default in ld/libtool. */
          ELSE
             cOpt_Dyn := "-shared -o {OD} {LO} {FD} {DL} {LS}"
          ENDIF


### PR DESCRIPTION
In Homebrew we have started auditing for the usage of flat namespaces in shared libraries, and have found that they are being used in binaries built by Harbour. The usage of flat namespaces is considered deprecated in modern versions of macOS (https://developer.apple.com/forums//thread/689991), and it can lead to build failures and symbol conflicts if a dynamically linked binary ends up linking to two libraries with identically named symbols.