### PR TITLE
Disabled debug code HB_CDX_DBGCODE

### DIFF
--- a/src/rdd/dbfcdx/dbfcdx1.c
+++ b/src/rdd/dbfcdx/dbfcdx1.c
@@ -54,8 +54,8 @@
 #  define HB_CDX_PACKTRAIL
 #endif
 
-#define HB_CDX_DBGCODE
 /*
+#define HB_CDX_DBGCODE
 #define HB_CDX_DBGCODE_EXT
 #define HB_CDX_DSPDBG_INFO
 #define HB_CDX_DBGTIME


### PR DESCRIPTION
disabled debug code HB_CDX_DBGCODE, It solve some issue with CGI code in case CDX be corrupted.