### PR TITLE
Minor warning fixes

### DIFF
--- a/include/hbwinuni.h
+++ b/include/hbwinuni.h
@@ -87,11 +87,11 @@
    #define HB_WINAPI_SYSTEM( cmd )               _wsystem( cmd )
    #define HB_WINAPI_KERNEL32_DLL()              ( hb_iswin9x() ? TEXT( "unicows.dll" ) : TEXT( "kernel32.dll" ) )
    #if defined( HB_OS_WIN_CE )
-      #define HB_WINAPI_GETPROCADDRESS( h, n )   GetProcAddress( h, TEXT( n ) )
-      #define HB_WINAPI_GETPROCADDRESST( h, n )  GetProcAddress( h, TEXT( n ) TEXT( "W" ) )
+      #define HB_WINAPI_GETPROCADDRESS( h, n )   ( void * ) GetProcAddress( h, TEXT( n ) )
+      #define HB_WINAPI_GETPROCADDRESST( h, n )  ( void * ) GetProcAddress( h, TEXT( n ) TEXT( "W" ) )
    #else
-      #define HB_WINAPI_GETPROCADDRESS( h, n )   GetProcAddress( h, n )
-      #define HB_WINAPI_GETPROCADDRESST( h, n )  GetProcAddress( h, n "W" )
+      #define HB_WINAPI_GETPROCADDRESS( h, n )   ( void * ) GetProcAddress( h, n )
+      #define HB_WINAPI_GETPROCADDRESST( h, n )  ( void * ) GetProcAddress( h, n "W" )
    #endif
 #else
    #define HB_PARSTR( n, h, len )                hb_parstr( n, hb_setGetOSCP(), h, len )
@@ -126,8 +126,8 @@
    #define HB_OSSTRDUP2( str, buf, len )         hb_osStrDecode2( str, buf, len )
    #define HB_WINAPI_SYSTEM( cmd )               system( cmd )
    #define HB_WINAPI_KERNEL32_DLL()              ( TEXT( "kernel32.dll" ) )
-   #define HB_WINAPI_GETPROCADDRESS( h, n )      GetProcAddress( h, n )
-   #define HB_WINAPI_GETPROCADDRESST( h, n )     GetProcAddress( h, n "A" )
+   #define HB_WINAPI_GETPROCADDRESS( h, n )      ( void * ) GetProcAddress( h, n )
+   #define HB_WINAPI_GETPROCADDRESST( h, n )     ( void * ) GetProcAddress( h, n "A" )
 #endif
 
 #endif /* HB_OS_WIN */

--- a/src/compiler/harbour.yyc
+++ b/src/compiler/harbour.yyc
@@ -3574,7 +3574,10 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
   yystate = 0;
   yyerrstatus = 0;
+
   yynerrs = 0;
+  HB_SYMBOL_UNUSED( yynerrs );
+
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 

--- a/src/macro/macro.yyc
+++ b/src/macro/macro.yyc
@@ -1668,7 +1668,10 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
   yystate = 0;
   yyerrstatus = 0;
+
   yynerrs = 0;
+  HB_SYMBOL_UNUSED( yynerrs );
+
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 

--- a/src/rtl/replic.c
+++ b/src/rtl/replic.c
@@ -63,7 +63,7 @@ HB_FUNC( REPLICATE )
       {
          if( nTimes == 1 )
             hb_itemReturn( pItem );
-         else if( ( double ) nLen * nTimes < HB_SIZE_MAX )
+         else if( ( double ) nLen * nTimes < ( double ) HB_SIZE_MAX )
          {
             const char * szText = hb_itemGetCPtr( pItem );
             HB_SIZE nSize = nLen * nTimes;

--- a/src/vm/classes.c
+++ b/src/vm/classes.c
@@ -508,7 +508,7 @@ static void hb_clsDictInit( PCLASS pClass, HB_SYMCNT uiHashKey )
 {
    HB_SIZE nSize;
 
-   HB_TRACE( HB_TR_DEBUG, ( "hb_clsDictInit(%p,%hu)", ( void * ) pClass, uiHashKey ) );
+   HB_TRACE( HB_TR_DEBUG, ( "hb_clsDictInit(%p,%u)", ( void * ) pClass, uiHashKey ) );
 
    pClass->uiHashKey = uiHashKey;
 #ifdef HB_MSG_POOL

--- a/src/vm/maindllp/dllpcode.c
+++ b/src/vm/maindllp/dllpcode.c
@@ -136,10 +136,10 @@ PHB_FUNC hb_dllGetProcAddress( const char * szProcName )
          {
 #if defined( HB_OS_WIN_CE )
             LPCTSTR s_lpGetProcAddr = TEXT( "_dll_hb_vmProcAddress" );
-            s_pProcGet = ( HB_PROC_GET ) GetProcAddress( s_hModule, s_lpGetProcAddr + i );
+            s_pProcGet = ( HB_PROC_GET ) ( void * ) GetProcAddress( s_hModule, s_lpGetProcAddr + i );
 #else
             static const char * s_szGetProcAddr = "_dll_hb_vmProcAddress";
-            s_pProcGet = ( HB_PROC_GET ) GetProcAddress( s_hModule, s_szGetProcAddr + i );
+            s_pProcGet = ( HB_PROC_GET ) ( void * ) GetProcAddress( s_hModule, s_szGetProcAddr + i );
 #endif
          }
          while( s_pProcGet == NULL && ( i -= i == 4 ? 3 : 1 ) >= 0 );


### PR DESCRIPTION
```
2023-11-11 18:38 UTC+0100 Phil Krylov (phil a t krylov.eu)
  * include/hbwinuni.h
  * src/vm/maindllp/dllpcode.c
    * In `HB_WINAPI_GETPROCADDRESS[T]`, cast the return value to `void *`
      to pacify further cast warnings, as the exact function signature
      is almost never a `FARPROC` anyway.
  * src/compiler/harbour.yyc
  * src/macro/macro.yyc
    * Added `HB_SYMBOL_UNUSED( yynerrs )` to pacify compiler warnings.
  * src/rtl/replic.c
    * Added a cast to a comparison to pacify compiler warning.
  * src/vm/classes.c
    ! Fixed outdated format specifier in a trace message.
```