### PR TITLE
Use -D__USE_MINGW_ANSI_STDIO=0 to opt out of C99 printf emulation on MinGW-W64 10.0+

### DIFF
--- a/config/win/mingw.mk
+++ b/config/win/mingw.mk
@@ -78,6 +78,13 @@ ifeq ($(HB_BUILD_DEBUG),yes)
    CFLAGS += -g
 endif
 
+ifeq ($(HB_COMPILER),mingw64)
+   # Newer MinGW-W64 versions (10+, IIRC) need this to opt out of C99 format
+   # string emulation and keep our format strings compatible among the
+   # different Windows compilers
+   CFLAGS += -D__USE_MINGW_ANSI_STDIO=0
+endif
+
 RC := $(HB_CCPATH)$(HB_CCPREFIX)windres
 RC_OUT := -o$(subst x,x, )
 RCFLAGS += -I. -I$(HB_HOST_INC) -O coff

--- a/utils/hbmk2/hbmk2.prg
+++ b/utils/hbmk2/hbmk2.prg
@@ -4385,6 +4385,14 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
             EXIT
          CASE _WARN_NO  ; AAdd( hbmk[ _HBMK_aOPTC ], "-w" )                 ; EXIT
          ENDSWITCH
+
+         IF hbmk[ _HBMK_cCOMP ] == "mingw64"
+            // Newer MinGW-W64 versions (10+, IIRC) need this to opt out of C99 format
+            // string emulation and keep our format strings compatible among the
+            // different Windows compilers
+            cOpt_CompC += " -D__USE_MINGW_ANSI_STDIO=0"
+         ENDIF
+
          IF hbmk[ _HBMK_lHARDEN ]
             IF hbmk[ _HBMK_cPLAT ] == "win"
                /* It is also supported by official mingw 4.4.x and mingw64 4.4.x,


### PR DESCRIPTION
2023-11-07 13:52 UTC+0100 Phil Krylov (phil a t krylov.eu)
  * config/win/mingw.mk
  * utils/hbmk2/hbmk2.prg
    ! Use -D__USE_MINGW_ANSI_STDIO=0 to opt out of C99 printf emulation on MinGW-W64 10.0+.