### PR TITLE
contrib/hbsqlit3: Fixed dangling pointer access with SQLITE3_TRACE(), SQLITE3_PROFILE()

### DIFF
--- a/contrib/hbsqlit3/tests/backup.prg
+++ b/contrib/hbsqlit3/tests/backup.prg
@@ -60,6 +60,10 @@
 
 #require "hbsqlit3"
 
+PROCEDURE init_trace( pDbDest, cPrefix )
+   sqlite3_trace( pDbDest, .T., cPrefix + ".log" )
+   RETURN
+
 PROCEDURE Main()
 
    LOCAL cFileSource := ":memory:", cFileDest := "backup.db", cSQLTEXT
@@ -85,7 +89,7 @@ PROCEDURE Main()
       RETURN
    ENDIF
 
-   sqlite3_trace( pDbDest, .T., "backup.log" )
+   init_trace( pDbDest, "backup" )
 
    pBackup := sqlite3_backup_init( pDbDest, "main", pDbSource, "main" )
    IF Empty( pBackup )


### PR DESCRIPTION
2023-11-15 15:57 UTC+0100 Phil Krylov (phil a t krylov.eu)
  * contrib/hbsqlit3/tests/backup.prg
    + Simple change in test to provoke access to dangling pointer saved by SQLITE3_TRACE().
  * contrib/hbsqlit3/core.c
    ! Fixed dangling pointer access with SQLITE3_TRACE(), SQLITE3_PROFILE().