### PR TITLE
contrib/hbsqlit3: Implemented SQLITE3_TRACE_V2(), SQLITE3_DB_FILENAME(), SQLITE3_EXPANDED_SQL()

### DIFF
--- a/contrib/hbsqlit3/hbsqlit3.ch
+++ b/contrib/hbsqlit3/hbsqlit3.ch
@@ -174,4 +174,10 @@
 #define SQLITE_LIMIT_VARIABLE_NUMBER       9
 #define SQLITE_LIMIT_TRIGGER_DEPTH         10
 
+/* Trace Event Codes */
+#define SQLITE_TRACE_STMT       0x01
+#define SQLITE_TRACE_PROFILE    0x02
+#define SQLITE_TRACE_ROW        0x04
+#define SQLITE_TRACE_CLOSE      0x08
+
 #endif

--- a/contrib/hbsqlit3/hbsqlit3.hbx
+++ b/contrib/hbsqlit3/hbsqlit3.hbx
@@ -72,6 +72,7 @@ DYNAMIC sqlite3_compileoption_get
 DYNAMIC sqlite3_compileoption_used
 DYNAMIC sqlite3_complete
 DYNAMIC sqlite3_create_function
+DYNAMIC sqlite3_db_filename
 DYNAMIC sqlite3_db_status
 DYNAMIC sqlite3_enable_load_extension
 DYNAMIC sqlite3_enable_shared_cache
@@ -79,6 +80,7 @@ DYNAMIC sqlite3_errcode
 DYNAMIC sqlite3_errmsg
 DYNAMIC sqlite3_errstr
 DYNAMIC sqlite3_exec
+DYNAMIC sqlite3_expanded_sql
 DYNAMIC sqlite3_extended_errcode
 DYNAMIC sqlite3_extended_result_codes
 DYNAMIC sqlite3_file_to_buff
@@ -116,6 +118,7 @@ DYNAMIC sqlite3_temp_directory
 DYNAMIC sqlite3_threadsafe
 DYNAMIC sqlite3_total_changes
 DYNAMIC sqlite3_trace
+DYNAMIC sqlite3_trace_v2
 
 #if defined( __HBEXTREQ__ ) .OR. defined( __HBEXTERN__HBSQLIT3__REQUEST )
    #uncommand DYNAMIC <fncs,...> => EXTERNAL <fncs>

--- a/contrib/hbsqlit3/tests/backup.prg
+++ b/contrib/hbsqlit3/tests/backup.prg
@@ -60,14 +60,37 @@
 
 #require "hbsqlit3"
 
-PROCEDURE init_trace( pDbDest, cPrefix )
-   sqlite3_trace( pDbDest, .T., cPrefix + ".log" )
+#include "fileio.ch"
+
+
+PROCEDURE init_trace( pDb, cPrefix )
+   LOCAL hFile
+   IF sqlite3_libversion_number() < 3014000
+      sqlite3_trace( pDb, .T., cPrefix + ".log" )
+   ELSE
+      hFile := FOpen( cPrefix + ".log", FO_READWRITE + HB_FO_CREAT )
+      FSeek( hFile, 0, FS_END )
+      sqlite3_trace_v2( pDb, SQLITE_TRACE_STMT + SQLITE_TRACE_CLOSE, {| nMask, p, x |
+         IF nMask == SQLITE_TRACE_STMT  /* p is pPreparedStatement, x is cOriginalSql */
+            IF hb_LeftEq( x, "--" )
+               FWrite( hFile, x + hb_eol() )
+            ELSE
+               FWrite( hFile, sqlite3_expanded_sql( p ) + hb_eol() )
+            ENDIF
+         ELSEIF nMask == SQLITE_TRACE_CLOSE  /* p is the database connection */
+            FWrite( hFile, "Closing the database connection: " + sqlite3_db_filename( p, "main" ) + hb_eol() )
+         ENDIF
+         RETURN 0
+      } )
+   ENDIF
    RETURN
 
 PROCEDURE Main()
 
    LOCAL cFileSource := ":memory:", cFileDest := "backup.db", cSQLTEXT
    LOCAL pDbSource, pDbDest, pBackup, cb, nDbFlags
+
+   ? "Using SQLite3 version " + hb_NToS( sqlite3_libversion_number() )
 
    IF sqlite3_libversion_number() < 3006011
       ErrorLevel( 1 )
@@ -167,7 +190,7 @@ STATIC FUNCTION PrepareDB( cFile )
       RETURN NIL
    ENDIF
 
-   sqlite3_trace( pDb, .T., "backup.log" )
+   init_trace( pDb, "backup" )
 
    cSQLTEXT := "CREATE TABLE person( name TEXT, age INTEGER )"
    IF sqlite3_exec( pDb, cSQLTEXT ) != SQLITE_OK


### PR DESCRIPTION
SQLite 3.14.0 deprecates `sqlite3_trace()` and `sqlite3_profile` functions, so they may be unavailable in the linked library. This PR is to be applied after #342.

2023-11-16 18:12 UTC+0100 Phil Krylov (phil a t krylov.eu)
  * contrib/hbsqlit3/core.c
  * contrib/hbsqlit3/hbsqlit3.ch
  * contrib/hbsqlit3/hbsqlit3.hbx
    * Implemented SQLITE3_DB_FILENAME() on SQLite 3.7.10+.
    * Implemented SQLITE3_EXPANDED_SQL(), SQLITE3_TRACE_V2() on SQLite 3.14.0+.
    ; Thanks to Mindaugas Kavaliauskas for thorough reviewing!
  * contrib/hbsqlit3/tests/backup.prg
  * contrib/hbsqlit3/tests/demo.prg
    * Updated examples to use SQLITE3_TRACE_V2() on SQLite 3.14.0+.
