### PR TITLE
Make oError:osCode return 2 on all platforms when an invalid filename is passed

### DIFF
--- a/src/rtl/fserr.c
+++ b/src/rtl/fserr.c
@@ -128,6 +128,7 @@ static HB_ERRCODE hb_WinToDosError( DWORD dwError )
    {
       case ERROR_PRIVILEGE_NOT_HELD:
       case ERROR_ALREADY_EXISTS:          return 5;
+      case ERROR_INVALID_NAME:
       case ERROR_FILE_NOT_FOUND:          return 2;
       case ERROR_PATH_NOT_FOUND:          return 3;
       case ERROR_TOO_MANY_OPEN_FILES:     return 4;


### PR DESCRIPTION
2023-12-01 11:00 UTC+0100 Phil Krylov (phil a t krylov.eu)
  * src/rtl/fserr.c
    * Mapped ERROR_INVALID_NAME on Windows to DOS error 2. Makes hbtest pass on Windows.