### PR TITLE
Fixed bcc32 warning flags

### DIFF
--- a/config/win/bcc.mk
+++ b/config/win/bcc.mk
@@ -25,9 +25,9 @@ CFLAGS += -I. -I$(HB_HOST_INC)
 CFLAGS += -q -tWM -CP437
 
 ifeq ($(HB_BUILD_WARN),no)
-   CFLAGS += -w-sig- -w-aus- -w-ccc- -w-csu- -w-par- -w-rch- -w-ucp- -w-use- -w-prc- -w-pia-
+   CFLAGS += -w-aus -w-ccc -w-csu -w-ovf -w-par -w-rch -w-spa
 else
-   CFLAGS += -w -Q -w-sig-
+   CFLAGS += -w -Q -w-sig
 endif
 
 ifneq ($(HB_BUILD_OPTIM),no)

--- a/utils/hbmk2/hbmk2.prg
+++ b/utils/hbmk2/hbmk2.prg
@@ -5048,8 +5048,9 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
          ENDIF
          SWITCH hbmk[ _HBMK_nWARN ]
          CASE _WARN_MAX ; AAdd( hbmk[ _HBMK_aOPTC ], "-w -Q" )         ; EXIT
-         CASE _WARN_YES ; AAdd( hbmk[ _HBMK_aOPTC ], "-w -Q -w-sig-" ) ; EXIT
-         CASE _WARN_LOW ; AAdd( hbmk[ _HBMK_aOPTC ], "-w-sig- -w-aus- -w-ccc- -w-csu- -w-par- -w-rch- -w-ucp- -w-use- -w-prc- -w-pia-" ) ; EXIT
+         CASE _WARN_YES ; AAdd( hbmk[ _HBMK_aOPTC ], "-w -Q -w-sig" ) ; EXIT
+         // The following line differs from the line in config/win/bcc.mk because Make needs to build core, and hbmk2 needs to build contrib
+         CASE _WARN_LOW ; AAdd( hbmk[ _HBMK_aOPTC ], "-w-sig -w-aus -w-ccc -w-csu -w-ovf -w-par -w-rch -w-spa -w-sus -w-pia" ) ; EXIT
          CASE _WARN_NO  ; AAdd( hbmk[ _HBMK_aOPTC ], "-w-" )           ; EXIT
          ENDSWITCH
          cOpt_CompC += " {FC} {LC}"


### PR DESCRIPTION
2023-12-07 21:00 UTC+0100 Phil Krylov (phil a t krylov.eu)
  * config/win/bcc.mk
  * utils/hbmk2/hbmk2.prg
    ! Fixed Borland C 32-bit compiler warning flags.