### PR TITLE
Update hbusage.c for the current year

### DIFF
--- a/src/compiler/hbusage.c
+++ b/src/compiler/hbusage.c
@@ -261,7 +261,7 @@ void hb_compPrintLogo( HB_COMP_DECL )
 {
    char * szVer = hb_verHarbour();
 
-   #define HB_VER_COMMIT_YEAR  "2021"
+   #define HB_VER_COMMIT_YEAR  "2024"
    #define HB_VER_ORIGIN_URL   "https://harbour.github.io/"
 
    hb_compOutStd( HB_COMP_PARAM, szVer );


### PR DESCRIPTION
Harbour can't be showing 2021. We are on 2024 and Harbour remains very much alive.