### PR TITLE
Fixed issue HB_SCAN for LOGICAL value

### DIFF
--- a/src/vm/hashfunc.c
+++ b/src/vm/hashfunc.c
@@ -610,7 +610,7 @@ HB_FUNC( HB_HSCAN )
       }
       else if( HB_IS_LOGICAL( pValue ) )
       {
-         HB_BOOL fValue = hb_itemGetDL( pValue );
+         HB_BOOL fValue = hb_itemGetL( pValue );
          while( nCount-- )
          {
             PHB_ITEM pItem = hb_hashGetValueAt( pHash, nStart );


### PR DESCRIPTION
2024-12-03 01:27 UTC-0300 Lailton Fernando Mariano (lailton/at/paysoft.com.br)
  * src/vm/hashfunc.c
    ! fixed issue hb_scan when we are looking for a logical value as true.
      Many thanks to Marcos Gambeta who found the problem.
      
Here an example reproduce the issue.

```prg
function main()

	LOCAL hHash := { "key1" => .T., "key2" => .F., "key3" => .T. }
	LOCAL lSearchValue := .T. // Logical value to search
	LOCAL nFoundIndex
	
	? "Hash table:", hHash
	? "Searching for:", lSearchValue
	
	
	// Use HB_HSCAN to find the logical value
	nFoundIndex := HB_HSCAN(hHash, lSearchValue)
	
	IF nFoundIndex > 0
		? "Logical value found at index:", nFoundIndex
	ELSE
		? "Logical value not found!"
	ENDIF

return nil


```

Expected result is return position 1.

More info:
[Harbour Developers - Group](https://groups.google.com/g/harbour-devel/c/dgAcY_O14Pc)