### PR TITLE
On branch rddsql_add_timestamp_support

### DIFF
--- a/contrib/rddsql/sqlbase.c
+++ b/contrib/rddsql/sqlbase.c
@@ -533,6 +533,7 @@ static HB_ERRCODE sqlbasePutValue( SQLBASEAREAP pArea, HB_USHORT uiIndex, PHB_IT
    errCode = HB_SUCCESS;
    pField  = pArea->area.lpFields + ( uiIndex - 1 );
 
+
    if( ( ( HB_IS_MEMO( pItem ) || HB_IS_STRING( pItem ) ) && ( pField->uiType == HB_FT_STRING || pField->uiType == HB_FT_MEMO ) ) ||
        ( HB_IS_DATE( pItem ) && pField->uiType == HB_FT_DATE ) ||
        ( HB_IS_TIMESTAMP( pItem ) && pField->uiType == HB_FT_TIMESTAMP ) ||
@@ -741,6 +742,12 @@ static HB_ERRCODE sqlbaseCreate( SQLBASEAREAP pArea, LPDBOPENINFO pOpenInfo )
          case HB_FT_DATE:
             pItem = hb_itemPutDS( NULL, NULL );
             break;
+
+         case HB_FT_TIMESTAMP:
+            {
+               pItem = hb_itemPutTDT( NULL, 0, 0 );
+               break;
+            }
 
          case HB_FT_LOGICAL:
             pItem = hb_itemPutL( NULL, HB_FALSE );

--- a/contrib/rddsql/sqlmix.c
+++ b/contrib/rddsql/sqlmix.c
@@ -1597,6 +1597,11 @@ static HB_ERRCODE sqlmixOrderCreate( SQLMIXAREAP pArea, LPDBORDERCREATEINFO pOrd
          uiLen = 8;
          break;
 
+      case HB_IT_TIMESTAMP:
+         bType = '@';
+         uiLen = 26;
+         break;
+
       case HB_IT_LOGICAL:
          bType = 'L';
          uiLen = 1;


### PR DESCRIPTION
Changes to be committed:
modified:   ChangeLog.txt
modified:   contrib/rddsql/sqlbase.c
modified:   contrib/rddsql/sqlmix.c

+ added support to timestamp field type. You can now use "@" in DbCreate as the timestamp field type. Thanks to Grigory Filatov for fixing crash!