### PR TITLE
Add installation paths for `docs` and `font` directories, and depbinpath for `QT6`

### DIFF
--- a/contrib/gtqtc/gtqtc.hbp
+++ b/contrib/gtqtc/gtqtc.hbp
@@ -29,6 +29,7 @@
 -depincpath=qt6:/usr/include/x86_64-linux-gnu/qt6{linux}
 -depincpath=qt6:/usr/local/opt/qt6/include{darwin}
 -depincpath=qt6:/usr/local/include/qt6{bsd}
+-depbinpath=qt6:/usr/lib/qt6/libexec{linux}
 -depfinish=qt6
 
 {!HBMK_HAS_QT6}-deppkgname=qt5:qt5

--- a/utils/hbmk2/pkg_inst.hbm
+++ b/utils/hbmk2/pkg_inst.hbm
@@ -15,6 +15,8 @@
 -instfile=inc_sub:include/*.ch
 -instfile=inc:*.hbx
 -instfile=tests:tests/*.*
+-instfile=docs:docs/*.*
+-instfile=font:font/*.*
 
 # setup target directories for installation
 # -----------------------------------------
@@ -38,8 +40,10 @@
 # import libraries belonging to project dependencies
 {!(HB_INSTALL_IMPLIB='no')}-instpath=depimplib:${hb_addons}/${hb_name}/lib/${hb_plat}/${hb_comp}/
 
-# misc files, public headers, tests
+# misc files, public headers, tests, docs, font
 -instpath=misc:${hb_addons}/${hb_name}/
 -instpath=inc:${hb_addons}/${hb_name}/
 -instpath=inc_sub:${hb_addons}/${hb_name}/include/
 -instpath=tests:${hb_addons}/${hb_name}/tests/
+-instpath=docs:${hb_addons}/${hb_name}/docs/
+-instpath=font:${hb_addons}/${hb_name}/font/


### PR DESCRIPTION
This Pull Request includes the following changes:

1. Added installation paths for `docs` and `font` directories in `pkg_inst.hbm`.
   This ensures consistent placement of these directories in the `addons` folder 
   for external projects.

2. Updated `gtqtc.hbp` to include `depbinpath` for QT6 on Linux. This change 
   resolves issues with locating `moc` and improves compatibility with QT6.
