### PR TITLE
Fix nTop not being assigned properly in ListBox:hitTest()

### DIFF
--- a/src/rtl/listbox.prg
+++ b/src/rtl/listbox.prg
@@ -397,7 +397,7 @@ METHOD getText( nPos ) CLASS ListBox
 METHOD hitTest( nMRow, nMCol ) CLASS ListBox
 
    LOCAL nRet
-   LOCAL nTop
+   LOCAL nTop := ::nTop
    LOCAL nHit := 0
 
    /* Check hit on the scrollbar */
@@ -411,7 +411,6 @@ METHOD hitTest( nMRow, nMCol ) CLASS ListBox
    IF ! ::lIsOpen .OR. Empty( ::cHotBox + ::cColdBox )
       nRet := 0
    ELSE
-      nTop := ::nTop
       IF ::lDropDown
          nTop++
       ENDIF


### PR DESCRIPTION
2025-01-08 13:14 UTC+0100 Kamil Przybylski (kprzybylski quay.pl) 
 * src/rtl/listbox.prg
    ! fixed nTop variable not being assigned properly in ListBox:hitTest()
    
Explanation:
nTop is only assigned if this condition is false
`IF ! ::lIsOpen .OR. Empty( ::cHotBox + ::cColdBox )`
Otherwise it remains as NIL, and later on it is used for addition and comparison.
This leads to a crash BASE/1081 Argument error: +