### PR TITLE
Fixed nTop not being incremented in ListBox:hitTest() for no-box dropdown 

### DIFF
--- a/src/rtl/listbox.prg
+++ b/src/rtl/listbox.prg
@@ -396,8 +396,8 @@ METHOD getText( nPos ) CLASS ListBox
 
 METHOD hitTest( nMRow, nMCol ) CLASS ListBox
 
-   LOCAL nRet
    LOCAL nTop := ::nTop
+   LOCAL nOffset := 0
    LOCAL nHit := 0
 
    /* Check hit on the scrollbar */
@@ -408,13 +408,13 @@ METHOD hitTest( nMRow, nMCol ) CLASS ListBox
       RETURN nHit
    ENDIF
 
-   IF ! ::lIsOpen .OR. Empty( ::cHotBox + ::cColdBox )
-      nRet := 0
-   ELSE
-      IF ::lDropDown
-         nTop++
-      ENDIF
+   IF ::lIsOpen .AND. ::lDropDown
+      nTop++
+   ENDIF
 
+   IF ::lIsOpen .AND. .NOT. Empty( ::cHotBox + ::cColdBox )
+
+      nOffset := 1
       DO CASE
       CASE nMRow == nTop
          DO CASE
@@ -435,35 +435,34 @@ METHOD hitTest( nMRow, nMCol ) CLASS ListBox
             RETURN HTBOTTOM
          ENDCASE
       CASE nMCol == ::nLeft
-         IF nMRow >= ::nTop .AND. ;
+         IF nMRow >= nTop .AND. ;
             nMRow <= ::nBottom
             RETURN HTLEFT
          ELSE
             RETURN HTNOWHERE
          ENDIF
       CASE nMCol == ::nRight
-         IF nMRow >= ::nTop .AND. ;
+         IF nMRow >= nTop .AND. ;
             nMRow <= ::nBottom
             RETURN HTRIGHT
          ELSE
             RETURN HTNOWHERE
          ENDIF
       ENDCASE
-      nRet := 1
    ENDIF
 
    DO CASE
    CASE ! ::lIsOpen
-   CASE nMRow < nTop + nRet
-   CASE nMRow > ::nBottom - nRet
-   CASE nMCol < ::nLeft + nRet
-   CASE nMCol <= ::nRight - nRet
-      RETURN ::nTopItem + nMRow - ( nTop + nRet )
+   CASE nMRow < nTop + nOffset
+   CASE nMRow > ::nBottom - nOffset
+   CASE nMCol < ::nLeft + nOffset
+   CASE nMCol <= ::nRight - nOffset
+      RETURN ::nTopItem + nMRow - ( nTop + nOffset )
    ENDCASE
 
    DO CASE
    CASE ! ::lDropDown
-   CASE nMRow != ::nTop
+   CASE nMRow != nTop
    CASE nMCol < ::nLeft
    CASE nMCol < ::nRight
       RETURN HTCLIENT
@@ -479,7 +478,7 @@ METHOD hitTest( nMRow, nMCol ) CLASS ListBox
       RETURN HTCAPTION
    ENDCASE
 
-   RETURN 0
+   RETURN HTNOWHERE
 
 METHOD insItem( nPos, cText, xData ) CLASS ListBox
 


### PR DESCRIPTION
  2025-01-08 13:14 UTC+0100 Kamil Przybylski (kprzybylski quay.pl)
  
  \* src/rtl/listbox.prg 
    \! fixed nTop not being incremented in ListBox:hitTest() for no-box dropdown
    \* replaced inconsistent references to ::nTop with nTop
    \* renamed variables to better reflect their role

Explanation:
-  With current logic, nTop in hitTest() was incremented for a dropdown **only** if it had boxes.
This caused no-box dropdowns to be off by 1 in calculations.
https://github.com/harbour/core/blob/56bd63589b3fee1415a4bf74e0defe31560bba6a/src/rtl/listbox.prg#L411-L416
- As suggested by @alcz in #371 the function referenced both `::nTop` and `nTop` inconsistently. I changed all referenced to `nTop`.
- Renamed variable `nRet` to `nOffset`, since it is misleading and isn't even returned by the function.
- Changed last line `RETURN 0` to `RETURN HTNOWHERE` to be more consistant and descriptive.