### PR TITLE
Add hbcurl ERRORBUFFER

### DIFF
--- a/contrib/hbcurl/core.c
+++ b/contrib/hbcurl/core.c
@@ -449,7 +449,9 @@ static size_t hb_curl_write_fhandle_callback( void * buffer, size_t size, size_t
 
 #define HB_CURL_DL_BUFF_SIZE_INIT  ( CURL_MAX_WRITE_SIZE * 4 )
 #define HB_CURL_DL_BUFF_SIZE_INCR  ( CURL_MAX_WRITE_SIZE * 4 )
+#if LIBCURL_VERSION_NUM >= 0x070100
 #define HB_CURL_ER_BUFF_SIZE_INIT  ( CURL_ERROR_SIZE )
+#endif
 
 static size_t hb_curl_write_buff_callback( void * buffer, size_t size, size_t nmemb, void * Cargo )
 {
@@ -592,7 +594,7 @@ static void hb_curl_buff_ul_free( PHB_CURL hb_curl )
       hb_curl->ul_pos = 0;
    }
 }
-
+#if LIBCURL_VERSION_NUM >= 0x070100
 static void hb_curl_buff_er_free( PHB_CURL hb_curl )
 {
    if( hb_curl && hb_curl->er_ptr )
@@ -602,7 +604,7 @@ static void hb_curl_buff_er_free( PHB_CURL hb_curl )
       hb_curl->er_len = 0;
    }
 }
-
+#endif
 static void hb_curl_buff_dl_free( PHB_CURL hb_curl )
 {
    if( hb_curl && hb_curl->dl_ptr )
@@ -669,7 +671,9 @@ static void PHB_CURL_free( PHB_CURL hb_curl, HB_BOOL bFree )
 
    hb_curl_buff_ul_free( hb_curl );
    hb_curl_buff_dl_free( hb_curl );
-   hb_curl_buff_er_free( hb_curl );   
+#if LIBCURL_VERSION_NUM >= 0x070100   
+   hb_curl_buff_er_free( hb_curl );
+#endif   
 
    if( hb_curl->pProgressCallback )
    {
@@ -975,12 +979,14 @@ HB_FUNC( CURL_EASY_SETOPT )
             /* HB_CURLOPT_CONV_FROM_UTF8_FUNCTION */
 
             /* Error */
+#if LIBCURL_VERSION_NUM >= 0x070100            
             case HB_CURLOPT_ER_BUFF_SETUP:
                hb_curl_buff_er_free( hb_curl );
                hb_curl->er_len = hb_parnldef( 3, HB_CURL_ER_BUFF_SIZE_INIT );
                hb_curl->er_ptr = ( unsigned char * ) hb_xgrab( hb_curl->er_len );
                res = curl_easy_setopt( hb_curl->curl, CURLOPT_ERRORBUFFER, hb_curl->er_ptr );
                break;
+#endif
             /* HB_CURLOPT_STDERR */
 
             case HB_CURLOPT_FAILONERROR:
@@ -2048,7 +2054,7 @@ HB_FUNC( CURL_EASY_DL_BUFF_GET )
    else
       hb_errRT_BASE( EG_ARG, 2010, NULL, HB_ERR_FUNCNAME, HB_ERR_ARGS_BASEPARAMS );
 }
-
+#if LIBCURL_VERSION_NUM >= 0x070100
 HB_FUNC( CURL_EASY_ER_BUFF_GET )
 {
    if( PHB_CURL_is( 1 ) )
@@ -2063,6 +2069,7 @@ HB_FUNC( CURL_EASY_ER_BUFF_GET )
    else
       hb_errRT_BASE( EG_ARG, 2010, NULL, HB_ERR_FUNCNAME, HB_ERR_ARGS_BASEPARAMS );
 }
+#endif
 
 #define HB_CURL_INFO_TYPE_INVALID  0
 #define HB_CURL_INFO_TYPE_STR      1

--- a/contrib/hbcurl/core.c
+++ b/contrib/hbcurl/core.c
@@ -2054,22 +2054,23 @@ HB_FUNC( CURL_EASY_DL_BUFF_GET )
    else
       hb_errRT_BASE( EG_ARG, 2010, NULL, HB_ERR_FUNCNAME, HB_ERR_ARGS_BASEPARAMS );
 }
-#if LIBCURL_VERSION_NUM >= 0x070100
+
 HB_FUNC( CURL_EASY_ER_BUFF_GET )
 {
    if( PHB_CURL_is( 1 ) )
    {
+#if LIBCURL_VERSION_NUM >= 0x070100
       PHB_CURL hb_curl = PHB_CURL_par( 1 );
 
       if( hb_curl )
          hb_retc( ( char * ) hb_curl->er_ptr );
       else
+#endif
          hb_retc_null();
    }
    else
       hb_errRT_BASE( EG_ARG, 2010, NULL, HB_ERR_FUNCNAME, HB_ERR_ARGS_BASEPARAMS );
 }
-#endif
 
 #define HB_CURL_INFO_TYPE_INVALID  0
 #define HB_CURL_INFO_TYPE_STR      1

--- a/contrib/hbcurl/hbcurl.ch
+++ b/contrib/hbcurl/hbcurl.ch
@@ -273,6 +273,7 @@
 #define HB_CURLOPT_UL_FHANDLE_SETUP           1011
 #define HB_CURLOPT_DL_FHANDLE_SETUP           1012
 #define HB_CURLOPT_DEBUGBLOCK                 1013
+#define HB_CURLOPT_ER_BUFF_SETUP              1014
 /* Compatibility ones. Please don't use these. */
 #define HB_CURLOPT_SETUPLOADFILE              HB_CURLOPT_UL_FILE_SETUP
 #define HB_CURLOPT_CLOSEUPLOADFILE            HB_CURLOPT_UL_FILE_CLOSE


### PR DESCRIPTION
This update integrates the use of ErrorBuffer in **hbcurl** to capture detailed error messages. It improves error handling by providing more descriptive feedback when a request fails, facilitating easier debugging and issue resolution.

### Example: Using `ERRORBUFFER` in **hbcurl**

This example demonstrates how to initialize and use the `ErrorBuffer` in hbcurl to capture detailed error messages.

1. **Initialize the ErrorBuffer**
   ```c
   curl_easy_setopt(curl, HB_CURLOPT_ER_BUFF_SETUP)
   ```

2. **Perform the request**
   ```c
   curl_easy_perform(curl)
   ```

3. **Retrieve the error message (if any)**
   ```c
   cErrorBuffer := curl_easy_er_buff_get(curl)
   if !Empty( cErrorBuffer )
       ? cErrorBuffer 
   endif
   ```

### Explanation

- `HB_CURLOPT_ER_BUFF_SETUP`: Configures the error buffer to capture detailed error messages during request execution.
- `curl_easy_er_buff_get(curl)`: Retrieves the error message if the request fails, providing more descriptive feedback for debugging.
- Doc: https://curl.se/libcurl/c/CURLOPT_ERRORBUFFER.html


