### PR TITLE
2025-01-24 19:12 UTC-0300 Mario Wan Stadnik (wanstadnik gmail.com)

### DIFF
--- a/utils/hbmk2/hbmk2.prg
+++ b/utils/hbmk2/hbmk2.prg
@@ -273,7 +273,7 @@ EXTERNAL hbmk_KEYW
 #define _HBMK_SPECDIR_CONTRIB   "contrib"
 #define _HBMK_SPECDIR_ADDONS    "addons"
 
-#define _HBMK_SIGN_TIMEURL      "http://timestamp.verisign.com/scripts/timstamp.dll"
+#define _HBMK_SIGN_TIMEURL      "http://timestamp.comodoca.com/authenticode"
 
 #define _HBMK_HBEXTREQ          "__HBEXTREQ__"
 #define _HBMK_WITH_TPL          "HBMK_WITH_%1$s"


### PR DESCRIPTION
2025-01-24 19:15 UTC-0300 Mario Wan Stadnik (wanstadnik gmail.com)
  * utils/hbmk2/hbmk2.prg
    * http://timestamp.verisign.com/scripts/timstamp.dll has limped along for the last few years and had been working in a sort of depreciated state, but the new owners of the certificate issuing business, DigiCert, have issued a migration alert so we are switching to: http://timestamp.comodoca.com/authenticode ; It allows the user to choose the algorithm: SHA256 or SH1