### PR TITLE
Added -keepc option to hbmk2 compiler

### DIFF
--- a/utils/hbmk2/hbmk2.prg
+++ b/utils/hbmk2/hbmk2.prg
@@ -524,8 +524,9 @@ EXTERNAL hbmk_KEYW
 #define _HBMK_lMarkdown         156
 #define _HBMK_lShellMode        157
 #define _HBMK_bOut              158
+#define _HBMK_bKeepCFiles       159
 
-#define _HBMK_MAX_              158
+#define _HBMK_MAX_              159
 
 #define _HBMK_DEP_CTRL_MARKER   ".control."  /* must be an invalid path */
 
@@ -1023,6 +1024,7 @@ STATIC FUNCTION hbmk_new( lShellMode )
    hbmk[ _HBMK_lDumpInfo ] := .F.
    hbmk[ _HBMK_lMarkdown ] := .F.
    hbmk[ _HBMK_bOut ] := @OutStd()
+   hbmk[ _HBMK_bKeepCFiles ] := .F.
 
    RETURN hbmk
 
@@ -2615,6 +2617,7 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
       CASE cParamL == "-fullstatic"      ; hbmk[ _HBMK_lSHARED ]    := .F. ; hbmk[ _HBMK_lSTATICFULL ] := .T. ; hbmk[ _HBMK_lSHAREDDIST ] := NIL
       CASE cParamL == "-pic"             ; hbmk[ _HBMK_lPIC ]       := .T.
       CASE cParamL == "-pic-"            ; hbmk[ _HBMK_lPIC ]       := .F.
+      CASE cParamL == "-keepc"           ; hbmk[ _HBMK_bKeepCFiles ] := .T.
       CASE cParamL == "-nohblib"         ; l_lNOHBLIB := .T.
       CASE cParamL == "-nohblib-"        ; l_lNOHBLIB := .F.
       CASE cParamL == "-nomiscsyslib"    ; l_lLIBSYSMISC := .F.
@@ -3820,7 +3823,12 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
                   ENDIF
                   RETURN _EXIT_WORKDIRCREATE
                ENDIF
-               lDeleteWorkDir := .T.
+
+               IF hbmk[ _HBMK_bKeepCFiles ]
+                  lDeleteWorkDir := .F.
+               ELSE
+                  lDeleteWorkDir := .T.
+               ENDIF
             ENDIF
          ENDIF
       ENDIF
@@ -6365,7 +6373,11 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
                ELSE
                   _hbmk_OutErr( hbmk, I_( "Warning: Stub helper .c program could not be created." ) )
                   IF ! hbmk[ _HBMK_lINC ]
-                     AEval( ListDirExt( hbmk[ _HBMK_aPRG ], hbmk[ _HBMK_cWorkDir ], ".c", .T. ), {| tmp | FErase( tmp ) } )
+
+                    IF ! hbmk[ _HBMK_bKeepCFiles ]
+                        AEval( ListDirExt( hbmk[ _HBMK_aPRG ], hbmk[ _HBMK_cWorkDir ], ".c", .T. ), {| tmp | FErase( tmp ) } )
+                    ENDIF
+
                   ENDIF
                   IF lDeleteWorkDir
                      hb_DirDelete( hbmk[ _HBMK_cWorkDir ] )
@@ -6474,7 +6486,11 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
                ELSE
                   _hbmk_OutErr( hbmk, I_( "Warning: Stub helper .cpp program could not be created." ) )
                   IF ! hbmk[ _HBMK_lINC ]
-                     AEval( ListDirExt( hbmk[ _HBMK_aPRG ], hbmk[ _HBMK_cWorkDir ], ".c", .T. ), {| tmp | FErase( tmp ) } )
+
+                    IF ! hbmk[ _HBMK_bKeepCFiles ]
+                        AEval( ListDirExt( hbmk[ _HBMK_aPRG ], hbmk[ _HBMK_cWorkDir ], ".c", .T. ), {| tmp | FErase( tmp ) } )
+                    ENDIF
+
                   ENDIF
                   IF lDeleteWorkDir
                      hb_DirDelete( hbmk[ _HBMK_cWorkDir ] )
@@ -7446,7 +7462,9 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
          FErase( FNameDirExtSet( l_cRESSTUB, hbmk[ _HBMK_cWorkDir ], cResExt ) )
       ENDIF
       IF ! hbmk[ _HBMK_lINC ] .OR. hbmk[ _HBMK_lCLEAN ]
-         AEval( ListDirExt( hbmk[ _HBMK_aPRG ], hbmk[ _HBMK_cWorkDir ], ".c", .T. ), {| tmp | FErase( tmp ) } )
+        IF ! hbmk[ _HBMK_bKeepCFiles ]
+            AEval( ListDirExt( hbmk[ _HBMK_aPRG ], hbmk[ _HBMK_cWorkDir ], ".c", .T. ), {| tmp | FErase( tmp ) } )
+        ENDIF
       ENDIF
       IF hbmk[ _HBMK_lCLEAN ]
          IF hbmk[ _HBMK_lINC ]
@@ -9120,9 +9138,7 @@ STATIC FUNCTION dep_evaluate( hbmk )
             IF hbmk[ _HBMK_lInfo ]
                _hbmk_OutStd( hbmk, hb_StrFormat( I_( "Dependency '%1$s' forcibly disabled" ), dep[ _HBMKDEP_cName ] ) )
             ENDIF
-            IF ! dep[ _HBMKDEP_lOptional ]
-               lAnyForcedOut := .T.
-            ENDIF
+            lAnyForcedOut := .T.
             LOOP
          ELSE
             IF hbmk[ _HBMK_lDEBUGDEPD ]
@@ -16000,7 +16016,8 @@ STATIC PROCEDURE ShowHelp( hbmk, lMore, lLong )
       , ;
       { "-plugin=<filename>" , I_( "add plugin. <filename> can be: .hb, .prg, .hrb" ) }, ;
       { "-pi=<filename>"     , I_( "pass input file to plugins" ) }, ;
-      { "-pflag=<f>"         , I_( "pass single flag to plugins" ) } }
+      { "-pflag=<f>"         , I_( "pass single flag to plugins" ) }, ;
+      { "-keepc"             , I_( "C files are not deleted after Harbour compiler" ) } }
 
    LOCAL aHdr_Opt_LongCmd := { ;
       "", ;


### PR DESCRIPTION
Hello Harbour team!
For the last two years I have been working on a GUI system for Harbour, called GTNAP.

https://github.com/frang75/harbour_nappgui/blob/master/contrib/gtnap/Readme.md

In my branch I have implemented the `-keepc` option of `hbmk2` to keep the C file so I can create debuggable solutions using VisualStudio or Xcode.

Every time I upgrade from harbour/core I have to reimplement this option, so I propose to introduce it in the master of the project.

Thanks in advance.