### PR TITLE
New dependency for latest curl mingw64 version

### DIFF
--- a/contrib/hbcurl/hbcurl.hbp
+++ b/contrib/hbcurl/hbcurl.hbp
@@ -4,6 +4,7 @@ hbcurl.hbm
 -depimplibs=curl:../bin/libcurl.dll
 -depimplibs=curl:../libcurl-4.dll
 -depimplibs=curl:../bin/libcurl-4.dll
+-depimplibs=curl:../bin/libcurl-x64.dll
 -depfinish=curl
 
 -iflag={bcc}-a


### PR DESCRIPTION
The latest version of curl has libcurl-x64.dll. If you don't specify it in the hbp, it generates an error that the dependency is not found.

-depimplibs=curl:../bin/libcurl-x64.dll