### PR TITLE
proposed fix for #338

### DIFF
--- a/include/hbapifs.h
+++ b/include/hbapifs.h
@@ -227,19 +227,6 @@ extern HB_EXPORT int        hb_fsCanWrite    ( HB_FHANDLE hFileHandle, HB_MAXINT
 #  define HB_USE_SHARELOCKS
 #  define HB_SHARELOCK_POS          0x7fffffffUL
 #  define HB_SHARELOCK_SIZE         0x1UL
-#  if defined( HB_USE_BSDLOCKS_OFF )
-#     undef HB_USE_BSDLOCKS
-#  elif defined( HB_OS_LINUX ) && \
-        ! defined( __WATCOMC__ ) && ! defined( HB_USE_BSDLOCKS )
-      /* default usage of BSD locks in *BSD systems for emulating
-       * MS-DOS/Windows DENY_* flags has been disabled because tests
-       * on FreeBSD 6.2 and macOS shows that this implementation
-       * can create self deadlock when used simultaneously with
-       * POSIX locks - thanks to Phil and Lorenzo for locating the
-       * problem and tests [druzus]
-       */
-#     define HB_USE_BSDLOCKS
-#  endif
 #endif
 
 #define HB_MAX_DRIVE_LENGTH   10

--- a/src/rtl/filebuf.c
+++ b/src/rtl/filebuf.c
@@ -491,7 +491,7 @@ static PHB_FILE s_fileExtOpen( PHB_FILE_FUNCS pFuncs, const char * pszFileName, 
 #if ! defined( HB_OS_UNIX )
    fResult = HB_TRUE;
 #else
-#  if defined( HB_USE_SHARELOCKS ) && ! defined( HB_USE_BSDLOCKS )
+#  if defined( HB_USE_SHARELOCKS )
    if( nExFlags & FXO_SHARELOCK )
    {
       if( iMode == FO_WRITE && fShared )
@@ -610,7 +610,7 @@ static PHB_FILE s_fileExtOpen( PHB_FILE_FUNCS pFuncs, const char * pszFileName, 
 
             if( pFile->uiLocks == 0 )
             {
-#if ! defined( HB_USE_SHARELOCKS ) || defined( HB_USE_BSDLOCKS )
+#if ! defined( HB_USE_SHARELOCKS )
                if( pFile->hFileRO != FS_ERROR )
                {
                   hb_fsClose( pFile->hFileRO );
@@ -621,7 +621,7 @@ static PHB_FILE s_fileExtOpen( PHB_FILE_FUNCS pFuncs, const char * pszFileName, 
                {
                   hb_fsClose( hFile );
                   hFile = FS_ERROR;
-#if defined( HB_USE_SHARELOCKS ) && ! defined( HB_USE_BSDLOCKS )
+#if defined( HB_USE_SHARELOCKS )
                   /* FIXME: possible race condition */
                   hb_fsLockLarge( pFile->hFile, HB_SHARELOCK_POS, HB_SHARELOCK_SIZE,
                                   FL_LOCK | FLX_SHARED );

--- a/src/rtl/filesys.c
+++ b/src/rtl/filesys.c
@@ -191,7 +191,7 @@
       #endif
    #endif
 #endif
-#if defined( HB_USE_SHARELOCKS ) && defined( HB_USE_BSDLOCKS )
+#if defined( HB_USE_SHARELOCKS )
    #include <sys/file.h>
 #endif
 #if defined( HB_OS_LINUX )
@@ -4729,18 +4729,6 @@ HB_FHANDLE hb_fsExtOpen( const char * pszFileName, const char * pDefExt,
 #if defined( HB_USE_SHARELOCKS )
    if( hFile != FS_ERROR && ( nExFlags & FXO_SHARELOCK ) != 0 )
    {
-#if defined( HB_USE_BSDLOCKS )
-      int iLock, iResult;
-      if( /* ( uiFlags & ( FO_READ | FO_WRITE | FO_READWRITE ) ) == FO_READ || */
-          ( uiFlags & ( FO_DENYREAD | FO_DENYWRITE | FO_EXCLUSIVE ) ) == 0 )
-         iLock = LOCK_SH | LOCK_NB;
-      else
-         iLock = LOCK_EX | LOCK_NB;
-      hb_vmUnlock();
-      HB_FAILURE_RETRY( iResult, flock( hFile, iLock ) );
-      hb_vmLock();
-      if( iResult != 0 )
-#else
       HB_USHORT uiLock;
       if( ( uiFlags & ( FO_READ | FO_WRITE | FO_READWRITE ) ) == FO_READ ||
           ( uiFlags & ( FO_DENYREAD | FO_DENYWRITE | FO_EXCLUSIVE ) ) == 0 )
@@ -4749,7 +4737,6 @@ HB_FHANDLE hb_fsExtOpen( const char * pszFileName, const char * pDefExt,
          uiLock = FL_LOCK | FLX_EXCLUSIVE;
 
       if( ! hb_fsLockLarge( hFile, HB_SHARELOCK_POS, HB_SHARELOCK_SIZE, uiLock ) )
-#endif
       {
          hb_fsClose( hFile );
          hFile = FS_ERROR;


### PR DESCRIPTION
* src/rdd/wacore.c
* src/rtl/filebuf.c
  + Fixed locking mechanism for SMB related networks and Linux kernel >= 5.5
  - Removed old HB_USE_BSDLOCKS implementation, now broken on Linux too