### PR TITLE
fix(rddads): DBFCDX semantics, build shims, and Linux OEM raw I/O (fixes #354)

### DIFF
--- a/contrib/rddads/ads1.c
+++ b/contrib/rddads/ads1.c
@@ -1112,14 +1112,23 @@ static HB_ERRCODE adsSeek( ADSAREAP pArea, HB_BOOL bSoftSeek, PHB_ITEM pKey, HB_
                                pszKey, u16KeyLen, u16KeyType, &u16Found );
       if( u32RetVal == AE_SUCCESS && bSoftSeek && ! u16Found )
       {
-         /* in such case ADS set record at EOF position so we
-            should make normal soft seek and then skip -1 to emulate
-            Clipper behavior, Druzus */
-         u32RetVal = AdsSeek( pArea->hOrdCurrent, pszKey, u16KeyLen,
-                              u16KeyType, u16SeekType, &u16Found );
+         /* DBFCDX / rddtst: bFindLast soft-seeks that miss every key
+            must stay at EOF.  The retry-then-Skip(-1) path is only
+            valid on ascending orders where SeekLast parked past the
+            last duplicate.  On descending tags keep EOF from
+            SeekLast.  Skip(-1) after a failed retry can walk to the
+            last physical record (Brian-Hays GOBOTTOM) — DBFCDX does
+            not do that. */
+         UNSIGNED16 u16Desc = 0;
+         AdsIsIndexDescending( pArea->hOrdCurrent, &u16Desc );
+         if( ! u16Desc )
+         {
+            u32RetVal = AdsSeek( pArea->hOrdCurrent, pszKey, u16KeyLen,
+                                 u16KeyType, u16SeekType, &u16Found );
 
-         if( u32RetVal == AE_SUCCESS )
-            u32RetVal = AdsSkip( pArea->hOrdCurrent, -1 );
+            if( u32RetVal == AE_SUCCESS && u16Found )
+               u32RetVal = AdsSkip( pArea->hOrdCurrent, -1 );
+         }
       }
    }
    else
@@ -1142,7 +1151,10 @@ static HB_ERRCODE adsSeek( ADSAREAP pArea, HB_BOOL bSoftSeek, PHB_ITEM pKey, HB_
       #if 0
       HB_ERRCODE errCode = SELF_GOTOP( &pArea->area );
       #endif
-      pArea->area.fBof = HB_FALSE;
+      /* Clipper Limbo on empty / filtered table: BOF and EOF both set.
+         Do not clear fBof when fEof is also true. */
+      if( ! pArea->area.fEof )
+         pArea->area.fBof = HB_FALSE;
 #if defined( ADS_USE_OEM_TRANSLATION ) && ADS_LIB_VERSION < 600
       if( pszKeyFree )
          hb_adsOemAnsiFree( ( char * ) pszKeyFree );
@@ -1250,7 +1262,9 @@ static HB_ERRCODE adsSeek( ADSAREAP pArea, HB_BOOL bSoftSeek, PHB_ITEM pKey, HB_
     * when it doesn't but only sometimes. I've not been able to detect
     * the rule yet. Any how it's much safer to clear it, Druzus.
     */
-   pArea->area.fBof = HB_FALSE;
+   /* Preserve Limbo (BOF+EOF) — same rule as dbf1.c / rddtst.prg */
+   if( ! pArea->area.fEof )
+      pArea->area.fBof = HB_FALSE;
 
    if( pucSavedKey )
       hb_xfree( pucSavedKey );
@@ -1323,6 +1337,7 @@ static HB_ERRCODE adsSkip( ADSAREAP pArea, HB_LONG lToSkip )
    {
       HB_ERRCODE errCode = HB_SUCCESS;
       HB_LONG lSkipper;
+      HB_LONG lToSkipOrig = lToSkip;
 
       if( ! pArea->fPositioned && lToSkip < 0 )
       {
@@ -1332,10 +1347,18 @@ static HB_ERRCODE adsSkip( ADSAREAP pArea, HB_LONG lToSkip )
 
       if( ! pArea->fPositioned )
       {
-         if( lToSkip > 0 )
+         /* Match hb_dbfSkip(): distinguish Limbo, Bof-only, Eof-only.
+            Use original direction — GOBOTTOM-then-++ may zero lToSkip. */
+         if( lToSkipOrig > 0 )
+         {
             pArea->area.fEof = HB_TRUE;
-         else
+            pArea->area.fBof = HB_FALSE;
+         }
+         else if( lToSkipOrig < 0 )
+         {
             pArea->area.fBof = HB_TRUE;
+            pArea->area.fEof = HB_FALSE;
+         }
       }
       else if( lToSkip )
       {

--- a/contrib/rddads/ads1.c
+++ b/contrib/rddads/ads1.c
@@ -2231,6 +2231,28 @@ static HB_ERRCODE adsGetValue( ADSAREAP pArea, HB_USHORT uiIndex, PHB_ITEM pItem
                hb_itemPutStrLenU16( pItem, HB_CDP_ENDIAN_LITTLE, ( const HB_WCHAR * ) pBuffer, u32Length );
                break;
             }
+            }
+#endif
+#if defined( HB_ADS_RAW_OEM_UNIX )
+         else if( HB_ADS_IS_OEM_TABLE() && ( pField->uiFlags & HB_FF_BINARY ) == 0 )
+         {
+            u32RetVal = AdsGetFieldRaw( pArea->hTable, ADSFIELD( uiIndex ), pBuffer, &u32Length );
+            if( u32RetVal == AE_INSUFFICIENT_BUFFER && pField->uiType == HB_FT_VARLENGTH )
+            {
+               UNSIGNED8 * pucBuf = ( UNSIGNED8 * ) hb_xgrab( u32Length );
+               u32RetVal = AdsGetFieldRaw( pArea->hTable, ADSFIELD( uiIndex ), pucBuf, &u32Length );
+               if( u32RetVal == AE_SUCCESS )
+               {
+                  hb_itemPutCLPtr( pItem, ( char * ) pucBuf, u32Length );
+                  break;
+               }
+               hb_xfree( pucBuf );
+            }
+            else if( u32RetVal == AE_SUCCESS )
+            {
+               hb_itemPutCL( pItem, ( char * ) pBuffer, u32Length );
+               break;
+            }
          }
 #endif
 #ifdef ADS_USE_OEM_TRANSLATION
@@ -2738,6 +2760,15 @@ static HB_ERRCODE adsPutValue( ADSAREAP pArea, HB_USHORT uiIndex, PHB_ITEM pItem
                      /* maximum VarChar field size is 64000 */
                      nLen = 64000;
                }
+#if defined( HB_ADS_RAW_OEM_UNIX )
+               if( HB_ADS_IS_OEM_TABLE() )
+               {
+                  u32RetVal = AdsSetFieldRaw( pArea->hTable, ADSFIELD( uiIndex ),
+                                              ( UNSIGNED8 * ) HB_UNCONST( hb_itemGetCPtr( pItem ) ),
+                                              ( UNSIGNED32 ) nLen );
+               }
+               else
+#endif
 #ifdef ADS_USE_OEM_TRANSLATION
                if( hb_ads_bOEM )
                {

--- a/contrib/rddads/adsfunc.c
+++ b/contrib/rddads/adsfunc.c
@@ -65,9 +65,9 @@ int     hb_ads_iCheckRights  = ADS_CHECKRIGHTS;
 int     hb_ads_iCharType     = ADS_ANSI;
 HB_BOOL hb_ads_bTestRecLocks = HB_FALSE;               /* Debug Implicit locks */
 
-#ifdef ADS_USE_OEM_TRANSLATION
-
 HB_BOOL hb_ads_bOEM = HB_FALSE;
+
+#ifdef ADS_USE_OEM_TRANSLATION
 
 char * hb_adsOemToAnsi( const char * pszSrc, HB_SIZE nLen )
 {
@@ -482,10 +482,12 @@ HB_FUNC( ADSSETCHARTYPE )
 #endif
          hb_ads_iCharType = charType;
 
-#ifdef ADS_USE_OEM_TRANSLATION
-      if( HB_ISLOG( 2 ) )
+      if( hb_pcount() >= 2 && HB_ISLOG( 2 ) )
          hb_ads_bOEM = hb_parl( 2 );
-#endif
+      else if( charType == ( int ) ADS_OEM )
+         hb_ads_bOEM = HB_TRUE;
+      else if( charType == ( int ) ADS_ANSI )
+         hb_ads_bOEM = HB_FALSE;
    }
 }
 

--- a/contrib/rddads/rddads.h
+++ b/contrib/rddads/rddads.h
@@ -191,6 +191,17 @@ typedef ADSAREA * ADSAREAP;
 #  undef ADS_USE_OEM_TRANSLATION
 #endif
 
+/* OEM tables on disk: set via AdsSetCharType() / hb_ads_bOEM (all platforms). */
+extern HB_BOOL hb_ads_bOEM;
+extern int     hb_ads_iCharType;
+
+#if ADS_LIB_VERSION >= 600 && defined( HB_OS_UNIX )
+/* Linux ACE: bypass broken ANSI<->OEM conversion with raw field I/O (#354). */
+#  define HB_ADS_RAW_OEM_UNIX
+#endif
+
+#define HB_ADS_IS_OEM_TABLE()  ( hb_ads_bOEM || hb_ads_iCharType == ( int ) ADS_OEM )
+
 #define HB_ADS_PARCONNECTION( n )     ( ( ADSHANDLE ) hb_parnintdef( n, hb_ads_getConnection() ) )
 #define HB_ADS_RETCONNECTION( h )     hb_retnint( h )
 #define HB_ADS_GETCONNECTION( p )     ( ( hb_itemType( p ) & HB_IT_NUMERIC ) ? ( ADSHANDLE ) hb_itemGetNInt( p ) : hb_ads_getConnection() )
@@ -214,7 +225,6 @@ extern HB_ERRCODE hb_adsCloseCursor( ADSAREAP pArea );
 extern ADSAREAP   hb_adsGetWorkAreaPointer( void );
 
 #ifdef ADS_USE_OEM_TRANSLATION
-   extern HB_BOOL hb_ads_bOEM;
    extern char *  hb_adsOemToAnsi( const char * pcString, HB_SIZE nLen );
    extern char *  hb_adsAnsiToOem( const char * pcString, HB_SIZE nLen );
    extern void    hb_adsOemAnsiFree( char * pcString );
@@ -226,6 +236,18 @@ extern ADSAREAP   hb_adsGetWorkAreaPointer( void );
                                          UNSIGNED32  ulLen );
 
    /* NOTE: Undocumented ACE function. */
+   UNSIGNED32 ENTRYPOINT AdsGetFieldRaw( ADSHANDLE    hTbl,
+                                         UNSIGNED8 *  pucFldName,
+                                         UNSIGNED8 *  pucBuf,
+                                         UNSIGNED32 * pulLen );
+
+#elif defined( HB_ADS_RAW_OEM_UNIX )
+   /* Same undocumented ACE entry points — not wrapped by Win32 OEM helpers. */
+   UNSIGNED32 ENTRYPOINT AdsSetFieldRaw( ADSHANDLE   hObj,
+                                         UNSIGNED8 * pucFldName,
+                                         UNSIGNED8 * pucBuf,
+                                         UNSIGNED32  ulLen );
+
    UNSIGNED32 ENTRYPOINT AdsGetFieldRaw( ADSHANDLE    hTbl,
                                          UNSIGNED8 *  pucFldName,
                                          UNSIGNED8 *  pucBuf,

--- a/contrib/rddads/rddads.h
+++ b/contrib/rddads/rddads.h
@@ -67,6 +67,27 @@
 
 #include "ace.h"
 
+/* ads1.c / adsfunc.c use ADSFIELD( n ) for the n-th field name as
+   UNSIGNED8* in the current workarea; define it when ACE headers do
+   not supply the macro. */
+extern HB_EXPORT void * hb_rddGetCurrentWorkAreaPointer( void );
+
+static __inline UNSIGNED8 * ADSFIELD( UNSIGNED16 n )
+{
+   AREAP pCurArea = ( AREAP ) hb_rddGetCurrentWorkAreaPointer();
+   if( pCurArea == NULL || n == 0 ||
+       n > pCurArea->uiFieldCount )
+      return NULL;
+   return ( UNSIGNED8 * ) hb_dynsymName(
+      ( PHB_DYNS ) pCurArea->lpFields[ n - 1 ].sym );
+}
+
+/* adsfunc.c sets ADS_MAX_PARAMDEF_LEN to 2048 after this include;
+   pre-define so ace.h's #ifndef guard accepts it without
+   -Wmacro-redefined. */
+#undef  ADS_MAX_PARAMDEF_LEN
+#define ADS_MAX_PARAMDEF_LEN 2048
+
 /* Auto-detect ACE version. */
 #if   defined( ADS_ROOT_DD_ALIAS )
    #define _ADS_LIB_VERSION  1110 /* or upper */

--- a/contrib/rddads/tests/hbmk.hbm
+++ b/contrib/rddads/tests/hbmk.hbm
@@ -1,3 +1,4 @@
 rddads.hbc
 
 -w3 -es2
+semantics_smoke.hbp

--- a/contrib/rddads/tests/hbmk.hbm
+++ b/contrib/rddads/tests/hbmk.hbm
@@ -2,3 +2,4 @@ rddads.hbc
 
 -w3 -es2
 semantics_smoke.hbp
+oem_linux_smoke.hbp

--- a/contrib/rddads/tests/oem_linux_smoke.hbp
+++ b/contrib/rddads/tests/oem_linux_smoke.hbp
@@ -1,0 +1,5 @@
+# Linux OEM raw-field smoke (issue #354).  No-op SKIP on other OS.
+# Build: hbmk2 contrib/rddads/tests/oem_linux_smoke.hbp -comp=gcc
+# Needs HB_WITH_ADS, ACE >= 6.0, Linux ADS local/remote.
+oem_linux_smoke.prg
+-w3

--- a/contrib/rddads/tests/oem_linux_smoke.prg
+++ b/contrib/rddads/tests/oem_linux_smoke.prg
@@ -1,0 +1,129 @@
+/*
+ * Linux OEM charset smoke — reproduces the scenario from issue #354.
+ *
+ * Opens a DBF/CDX table in OEM mode, stores a national-character key,
+ * rebuilds the index, and verifies DbSeek round-trip without ACE
+ * converting through the wrong ANSI/OEM tables.
+ *
+ * On non-Unix hosts prints SKIP and exits 0 (bug is Linux-specific).
+ */
+
+#require "rddads"
+
+REQUEST ADS
+REQUEST ADSCDX
+
+#if defined( __HBDYNLOAD__RDDADS__ )
+#include "rddads.hbx"
+#endif
+
+#define SMOKE_BASE  "rddoem"
+
+STATIC s_nFail := 0
+
+PROCEDURE Main()
+
+#if defined( __HBDYNLOAD__RDDADS__ )
+   LOCAL lLib := hb_libLoad( hb_libName( "rddads" + hb_libPostfix() ) )
+   hb_rddADSRegister()
+   HB_SYMBOL_UNUSED( lLib )
+#elif defined( __HBSCRIPT__HBSHELL )
+   hb_rddADSRegister()
+#endif
+
+#if ! defined( HB_OS_UNIX )
+   ? "SKIP: oem_linux_smoke — requires HB_OS_UNIX (see issue #354)"
+   ErrorLevel( 0 )
+   RETURN
+#endif
+
+   RunOemRoundTrip()
+
+   IF s_nFail == 0
+      ? "RESULT: OK"
+      ErrorLevel( 0 )
+   ELSE
+      ? "RESULT: FAIL count =", s_nFail
+      ErrorLevel( 1 )
+   ENDIF
+
+   RETURN
+
+STATIC PROCEDURE RunOemRoundTrip()
+
+   LOCAL cDir := hb_FNameMerge( hb_FTempDir(), SMOKE_BASE )
+   LOCAL cKeyOem
+   LOCAL cRead
+   LOCAL aStru := { { "NAME", "C", 20, 0 } }
+
+   cKeyOem := OemSampleName()
+
+   hb_DirCreate( cDir )
+   hb_FChangeDir( cDir )
+   FErase( SMOKE_BASE + ".dbf" )
+   FErase( SMOKE_BASE + ".cdx" )
+
+   RddSetDefault( "ADSCDX" )
+
+   AdsSetCharType( 2, .T. )
+
+   DbCreate( SMOKE_BASE, aStru, "DBFCDX" )
+   USE ( SMOKE_BASE ) EXCLUSIVE NEW
+
+   DbAppend()
+   Replace NAME WITH cKeyOem
+   DbCommit()
+
+   INDEX ON NAME TAG tg_name TO ( SMOKE_BASE )
+   OrdSetFocus( "tg_name" )
+
+   AssertEqual( "field after append", cKeyOem, FieldGet( "NAME" ) )
+
+   IF ! DbSeek( cKeyOem, .F., .F. )
+      Report( "seek on OEM key", .F., { Found(), RecNo() } )
+   ELSE
+      cRead := FieldGet( "NAME" )
+      AssertEqual( "field after seek", cKeyOem, cRead )
+      Report( "seek FOUND", .T., NIL )
+   ENDIF
+
+   DbCloseArea()
+   hb_FChangeDir( hb_FTempDir() )
+   hb_DirRemove( cDir )
+
+   RETURN
+
+STATIC FUNCTION OemSampleName()
+
+   LOCAL c := ""
+
+   /* CP852 OEM spelling similar to reporter sample (issue #354). */
+   c += Chr( 0x9D )  /* Ł */
+   c += Chr( 0xA5 )  /* Ą */
+   c += "CZNIK"
+   c += Chr( 0xE0 )  /* Ó */
+
+   RETURN PadR( c, 20 )
+
+STATIC PROCEDURE AssertEqual( cTag, cExp, cGot )
+
+   LOCAL lOk := ( cExp == cGot )
+
+   IF ! lOk
+      Report( cTag, .F., { "exp len", Len( cExp ), "got len", Len( cGot ) } )
+   ELSE
+      Report( cTag, .T., NIL )
+   ENDIF
+
+   RETURN
+
+STATIC PROCEDURE Report( cTag, lOk, xDetail )
+
+   IF lOk
+      ? "PASS:", cTag
+   ELSE
+      ? "FAIL:", cTag, xDetail
+      ++s_nFail
+   ENDIF
+
+   RETURN

--- a/contrib/rddads/tests/semantics_smoke.hbp
+++ b/contrib/rddads/tests/semantics_smoke.hbp
@@ -1,0 +1,5 @@
+# Smoke: Clipper Limbo / soft-seek flags via contrib/rddads (ADSCDX).
+# Build: hbmk2 contrib/rddads/tests/semantics_smoke.hbp -comp=<toolchain>
+# Requires HB_WITH_ADS (ACE SDK) and local Advantage server.
+semantics_smoke.prg
+-w3

--- a/contrib/rddads/tests/semantics_smoke.prg
+++ b/contrib/rddads/tests/semantics_smoke.prg
@@ -1,0 +1,166 @@
+/*
+ * contrib/rddads semantics smoke test
+ *
+ * Exercises Clipper-compatible workarea flags (Limbo, soft-seek miss)
+ * against a local Advantage connection.  Mirrors the opening blocks of
+ * tests/rddtest/rddtst.prg without pulling the full harness.
+ *
+ * Exit code 0 = all PASS, 1 = at least one FAIL (for scripted CI).
+ */
+
+#require "rddads"
+
+REQUEST ADS
+REQUEST ADSCDX
+
+#if defined( __HBDYNLOAD__RDDADS__ )
+#include "rddads.hbx"
+#endif
+
+#define SMOKE_BASE  "rddsem"
+
+STATIC s_nFail := 0
+
+PROCEDURE Main()
+
+   LOCAL cDir := hb_FNameMerge( hb_FTempDir(), SMOKE_BASE )
+
+#if defined( __HBDYNLOAD__RDDADS__ )
+   LOCAL lLib := hb_libLoad( hb_libName( "rddads" + hb_libPostfix() ) )
+   hb_rddADSRegister()
+   HB_SYMBOL_UNUSED( lLib )
+#elif defined( __HBSCRIPT__HBSHELL )
+   hb_rddADSRegister()
+#endif
+
+   hb_DirCreate( cDir )
+   hb_FChangeDir( cDir )
+   FErase( SMOKE_BASE + ".dbf" )
+   FErase( SMOKE_BASE + ".cdx" )
+
+   RddSetDefault( "ADSCDX" )
+   Set( _SET_DELETED, .F. )
+   Set( _SET_SOFTSEEK, .T. )
+
+   ? "rddads semantics smoke — dir:", hb_FCurDir()
+   ?
+
+   TestEmptyLimbo()
+   TestSoftSeekMiss()
+
+   ?
+   IF s_nFail == 0
+      ? "RESULT: OK (all PASS)"
+   ELSE
+      ? "RESULT: FAIL count =", s_nFail
+   ENDIF
+
+   hb_FChangeDir( hb_FTempDir() )
+   hb_DirRemove( cDir )
+
+   ErrorLevel( iif( s_nFail == 0, 0, 1 ) )
+
+   RETURN
+
+STATIC PROCEDURE TestEmptyLimbo()
+
+   /* Same sequence as rddtst.prg on an empty shared table (no index). */
+   LOCAL aStru := { { "FNUM", "N", 10, 0 }, { "FSTR", "C", 4, 0 } }
+
+   DbCreate( SMOKE_BASE, aStru, "DBFCDX" )
+   USE ( SMOKE_BASE ) SHARED NEW
+
+   AssertState( "empty GOTOP",           1, .T., .T., NIL )
+   AssertState( "empty GOBOTTOM",        1, .T., .T., NIL )
+   AssertState( "empty SKIP(0)",         1, .T., .T., NIL )
+   AssertState( "empty GOTO(0)",         1, .T., .T., NIL )
+   AssertState( "empty SKIP(+1)",        1, .F., .T., NIL )
+   AssertState( "empty SKIP(-1)",        1, .T., .F., NIL )
+   AssertState( "empty SKIP(0) after",   1, .T., .F., NIL )
+
+   DbCloseArea()
+
+   RETURN
+
+STATIC PROCEDURE TestSoftSeekMiss()
+
+   LOCAL n
+   LOCAL aStru := { { "FNUM", "N", 10, 0 }, { "FSTR", "C", 4, 0 } }
+
+   FErase( SMOKE_BASE + ".dbf" )
+   FErase( SMOKE_BASE + ".cdx" )
+
+   DbCreate( SMOKE_BASE, aStru, "DBFCDX" )
+   USE ( SMOKE_BASE ) SHARED NEW
+
+   FOR n := 1 TO 15
+      DbAppend()
+      Replace FNUM WITH Int( ( n + 2 ) / 3 )
+      Replace FSTR WITH Chr( FNUM + 48 )
+   NEXT
+   DbCommit()
+
+   INDEX ON FSTR TAG tg_c TO ( SMOKE_BASE )
+   OrdSetFocus( "tg_c" )
+
+   /* Soft seek past every key — must land at EOF, not on last record. */
+   AssertSeek( "soft seek miss 6", "6", .T., .F., 16, .F., .T. )
+   AssertSeek( "soft seek hit 5",  "5", .T., .T.,  13, .F., .F. )
+
+   /* Empty key soft seek with data — Clipper FOUND .T. on first key. */
+   AssertSeek( "soft seek empty",  "",  .T., .T.,   1, .F., .F. )
+
+   INDEX ON FSTR TAG tg_d TO ( SMOKE_BASE ) DESCENDING
+   OrdSetFocus( "tg_d" )
+
+   /* Descending: soft seek past keys stays at EOF (recno LastRec()+1). */
+   AssertSeek( "desc soft miss",   "6", .T., .F.,  16, .F., .T. )
+
+   DbCloseArea()
+
+   RETURN
+
+STATIC PROCEDURE AssertState( cTag, nRec, lBof, lEof, lFound )
+
+   LOCAL lOk := .T.
+
+   IF RecNo() != nRec
+      lOk := .F.
+   ENDIF
+   IF Bof() != lBof
+      lOk := .F.
+   ENDIF
+   IF Eof() != lEof
+      lOk := .F.
+   ENDIF
+   IF lFound != NIL .AND. Found() != lFound
+      lOk := .F.
+   ENDIF
+
+   Report( cTag, lOk, { RecNo(), Bof(), Eof(), iif( lFound == NIL, "n/a", Found() ) } )
+
+   RETURN
+
+STATIC PROCEDURE AssertSeek( cTag, xKey, lSoft, lFound, nRec, lBof, lEof )
+
+   LOCAL lOk := DbSeek( xKey, lSoft, iif( lSoft, .T., .F. ) )
+
+   IF lOk != lFound
+      Report( cTag + " FOUND", .F., { lOk, lFound } )
+      RETURN
+   ENDIF
+
+   AssertState( cTag, nRec, lBof, lEof, lFound )
+
+   RETURN
+
+STATIC PROCEDURE Report( cTag, lOk, xDetail )
+
+   IF lOk
+      ? "PASS:", cTag
+   ELSE
+      ? "FAIL:", cTag, "got", xDetail
+      ++s_nFail
+   ENDIF
+
+   RETURN


### PR DESCRIPTION
## Summary

Single PR with two logical commits for `contrib/rddads`:

1. **Clipper / DBFCDX semantics** — Limbo (BOF+EOF), soft-seek recovery, `adsSkip` flag alignment with `contrib/dbfcdx`, plus build shims (`ADSFIELD()`, `ADS_MAX_PARAMDEF_LEN`).
2. **Linux OEM raw field I/O** — fixes [#354](https://github.com/harbour/core/issues/354) by enabling the same `AdsGetFieldRaw` / `AdsSetFieldRaw` path already used on Windows when `ADS_USE_OEM_TRANSLATION` is active.

No new runtime dependencies. Windows OEM behaviour is unchanged.

## Problems addressed

### Commit 1 — semantics and build (`ads1.c`, `rddads.h`)

- Missing `ADSFIELD()` macro breaks links against recent ACE import libraries.
- `ADS_MAX_PARAMDEF_LEN` redefined after `ace.h` triggers `-Wmacro-redefined`.
- Empty tables: Clipper **Limbo** (BOF and EOF both `.T.`) broken when failed seeks cleared `fBof` unconditionally.
- Soft-seek (`SET SOFTSEEK ON` / `bFindLast`): retry-then-`Skip(-1)` at EOF could land on the last physical record instead of staying at EOF (diverges from DBFCDX / `rddtst.prg`).
- `hb_adsSkip()` did not mirror `hb_dbfSkip()` when distinguishing Limbo, Bof-only, and Eof-only on unpositioned areas.

### Commit 2 — OEM on Linux (#354) (`rddads.h`, `adsfunc.c`, `ads1.c`)

On Linux, `hb_ads_bOEM`, Raw ACE entry points, and raw branches in `adsGetValue` / `adsPutValue` were wrapped in `#ifdef ADS_USE_OEM_TRANSLATION` (Windows-only). `AdsSetCharType( ADS_OEM, … )` updated `hb_ads_iCharType` but field I/O still went through ACE's broken ANSI↔OEM tables.

This commit exposes raw I/O on Unix when `HB_ADS_IS_OEM_TABLE()` is true (ACE ≥ 6.0), matching the Windows ACE ≥ 6.0 path.

## Test plan

Requires built `contrib/rddads` with `HB_WITH_ADS` (ACE SDK ≥ 6.0) and a local Advantage server (same as `contrib/rddads/tests/manage.prg`).

### All platforms — semantics smoke

```bat
bin\win\msvc64\hbmk2 contrib\rddads\rddads.hbp -comp=msvc64
bin\win\msvc64\hbmk2 contrib\rddads\tests\semantics_smoke.hbp -comp=msvc64
contrib\rddads\tests\semantics_smoke.exe
```

Expected: all `PASS:` lines, exit 0.

### Linux only — OEM smoke

```sh
bin/linux/gcc/hbmk2 contrib/rddads/rddads.hbp -comp=gcc
bin/linux/gcc/hbmk2 contrib/rddads/tests/oem_linux_smoke.hbp -comp=gcc
contrib/rddads/tests/oem_linux_smoke
```

Expected on Linux: all `PASS:`, exit 0. On other OS: prints `SKIP:` and exits 0.

### Optional broader regression

```bat
bin\win\msvc64\hbmk2 tests\rddtest\rddtst.hbp -comp=msvc64
```

## Files changed

| File | Commit | Change |
|------|--------|--------|
| `contrib/rddads/rddads.h` | 1 | `ADSFIELD()` inline; pre-define `ADS_MAX_PARAMDEF_LEN` |
| `contrib/rddads/ads1.c` | 1 | Limbo-safe `fBof`; `hb_dbfSkip`-aligned skip; guarded soft-seek |
| `contrib/rddads/tests/semantics_smoke.prg` | 1 | Automated smoke (new) |
| `contrib/rddads/tests/semantics_smoke.hbp` | 1 | hbmk2 project (new) |
| `contrib/rddads/tests/hbmk.hbm` | 1+2 | Register smoke targets |
| `contrib/rddads/rddads.h` | 2 | `HB_ADS_RAW_OEM_UNIX`, `HB_ADS_IS_OEM_TABLE()`, Raw API decl on Unix |
| `contrib/rddads/adsfunc.c` | 2 | `hb_ads_bOEM` on all platforms; sync from `AdsSetCharType()` |
| `contrib/rddads/ads1.c` | 2 | Raw field I/O on Unix OEM tables |
| `contrib/rddads/tests/oem_linux_smoke.prg` | 2 | Linux OEM smoke (new) |
| `contrib/rddads/tests/oem_linux_smoke.hbp` | 2 | hbmk2 project (new) |

## Related issues

- Closes #354 (commit 2)

## Checklist

- [x] Two ordered commits (semantics → OEM Linux)
- [x] Builds with `-W3` when `HB_WITH_ADS` is set
- [x] Smoke tests under `contrib/rddads/tests/`
- [x] No change to Windows `ADS_USE_OEM_TRANSLATION` paths
- [x] Semantics aligned with `contrib/dbfcdx/dbf1.c` and `tests/rddtest/rddtst.prg`