### PR TITLE
hbtip: fix MIME-Version header capitalization

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -7,6 +7,10 @@
    Entries may not always be in chronological/commit order.
    See license at the end of file. */
 
+2026-08-16 17:31 UTC+0200 Damian Szlage (damian szlage.pl)
+  * contrib/hbtip/mail.prg
+    ! MIME-Version header capitalization
+
 2026-07-07 12:05 UTC+0200 Antonio Linares
   * include/hbver.h
   * config/global.mk

--- a/contrib/hbtip/mail.prg
+++ b/contrib/hbtip/mail.prg
@@ -255,7 +255,7 @@ METHOD HeadersToString() CLASS TIPMail
    NEXT
 
    IF ! Empty( ::aAttachments )
-      cRet += "Mime-Version: " + ::hHeaders[ "Mime-Version" ] + e"\r\n"
+      cRet += "MIME-Version: " + ::hHeaders[ "Mime-Version" ] + e"\r\n"
    ENDIF
 
    FOR EACH i IN ::hHeaders


### PR DESCRIPTION
Change the generated MIME header from Mime-Version to the conventional MIME-Version form.

Header field names are case-insensitive, so this does not change protocol semantics, but it avoids unnecessary MV_CASE scoring in Rspamd and other scanners.