### PR TITLE
Fix CI on 32-bit Windows, Solaris+gcc15, gcc16

### DIFF
--- a/.github/workflows/vm2-ci.yml
+++ b/.github/workflows/vm2-ci.yml
@@ -15,7 +15,7 @@ jobs:
           - name: freebsd
             version: "14.0"
           - name: omnios
-            version: "r151046"
+            version: "r151058"
           - name: solaris
             version: "11.4"
         compiler:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -55,24 +55,25 @@ jobs:
             mingw-w64-${{ env.msys_cpu }}-ccache
             mingw-w64-${{ env.msys_cpu }}-gcc
             mingw-w64-${{ env.msys_cpu }}-make
-            mingw-w64-${{ env.msys_cpu }}-allegro
             mingw-w64-${{ env.msys_cpu }}-bzip2
-            mingw-w64-${{ env.msys_cpu }}-cairo
             mingw-w64-${{ env.msys_cpu }}-curl
-            mingw-w64-${{ env.msys_cpu }}-ghostscript
             mingw-w64-${{ env.msys_cpu }}-openssl
             openssl-devel
 
       - name: 'Add packages available on 64-bit hosts only'
         if: matrix.cpu != 'x86'
         shell: msys2 {0}
-        run: |
-          pacman -S --noconfirm mingw-w64-${{ env.msys_cpu }}-postgresql
-          pacman -S --noconfirm mingw-w64-${{ env.msys_cpu }}-qt5-base
-          pacman -S --noconfirm mingw-w64-${{ env.msys_cpu }}-libgd
-          pacman -S --noconfirm mingw-w64-${{ env.msys_cpu }}-libmariadbclient
-          pacman -S --noconfirm mingw-w64-${{ env.msys_cpu }}-firebird
-          pacman -S --noconfirm mingw-w64-${{ env.msys_cpu }}-freeimage
+        run: >
+            pacman -S --noconfirm
+            mingw-w64-${{ env.msys_cpu }}-allegro
+            mingw-w64-${{ env.msys_cpu }}-cairo
+            mingw-w64-${{ env.msys_cpu }}-firebird
+            mingw-w64-${{ env.msys_cpu }}-freeimage
+            mingw-w64-${{ env.msys_cpu }}-ghostscript
+            mingw-w64-${{ env.msys_cpu }}-libgd
+            mingw-w64-${{ env.msys_cpu }}-libmariadbclient
+            mingw-w64-${{ env.msys_cpu }}-postgresql
+            mingw-w64-${{ env.msys_cpu }}-qt5-base
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -7,6 +7,31 @@
    Entries may not always be in chronological/commit order.
    See license at the end of file. */
 
+2026-08-26 19:55 UTC+0100 Phil Krylov (phil a t krylov.eu)
+  * .github/workflows/vm2-ci.yml
+    ! Fixed OmniOS release number to match VM.
+
+  * .github/workflows/windows-ci.yml
+    ! MSYS2 no longer ships 32-bit allegro, cairo, and ghostscript.
+
+  * contrib/hbhpdf/3rd/libhpdf/hpdfstre.c
+    ! Fix accidental usage of variable-length arrays extension.
+
+  * contrib/hbzebra/datamtrx.c
+    ! Extend -Warray-bounds warning pacification to GCC 16.
+
+  * contrib/sddsqlt3/core.c
+    ! Fix an unused assignment warning.
+
+  * src/rtl/gtcrs/gtcrs.h
+    ! Fix building on Oracle Solaris with GCC 15 and native curses.h.
+
+  * src/vm/dlmalloc.c
+    ! Silence an unused variable warning when assertions are off.
+
+  * src/vm/macro.c
+    ! Extend GCC 15+ -Wstringop-overflow warning pacification to Solaris.
+
 2026-08-26 13:17 UTC+0100 Phil Krylov (phil a t krylov.eu)
   * doc/en/hashfunc.txt
     ! Fixed return value documentation for hb_HPairAt()

--- a/contrib/hbhpdf/3rd/libhpdf/hpdfstre.c
+++ b/contrib/hbhpdf/3rd/libhpdf/hpdfstre.c
@@ -566,7 +566,7 @@ HPDF_Stream_WriteToStreamWithDeflate  (HPDF_Stream  src,
 {
 #ifndef LIBHPDF_HAVE_NOZLIB
 
-#define DEFLATE_BUF_SIZ  ((HPDF_INT)(HPDF_STREAM_BUF_SIZ * 1.1) + 13)
+#define DEFLATE_BUF_SIZ  (HPDF_STREAM_BUF_SIZ * 11 / 10 + 13)
 
     HPDF_STATUS ret;
     HPDF_BOOL flg;

--- a/contrib/hbzebra/datamtrx.c
+++ b/contrib/hbzebra/datamtrx.c
@@ -66,7 +66,7 @@
 
 #include "hbzebra.h"
 
-#if defined( __GNUC__ ) && __GNUC__ >= 12 && __GNUC__ <= 15
+#if defined( __GNUC__ ) && __GNUC__ >= 12 && __GNUC__ <= 16
    /* workaround for GCC bug */
    #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif

--- a/contrib/sddsqlt3/core.c
+++ b/contrib/sddsqlt3/core.c
@@ -330,14 +330,15 @@ static HB_ERRCODE sqlite3Disconnect( SQLDDCONNECTION * pConnection )
 static HB_ERRCODE sqlite3Execute( SQLDDCONNECTION * pConnection, PHB_ITEM pItem )
 {
    sqlite3 *  pDb = ( ( SDDCONN * ) pConnection->pSDDConn )->pDb;
-   HB_ERRCODE errCode;
    int        iRow, iCol;
    void *     hStatement;
    char **    pResult   = NULL;
-   char *     pszErrMsg = NULL;
 
    if( sqlite3_get_table( pDb, S_HB_ITEMGETSTR( pItem, &hStatement, NULL ), &pResult, &iRow, &iCol, NULL ) != SQLITE_OK )
    {
+      HB_ERRCODE errCode;
+      char *     pszErrMsg;
+
       hb_strfree( hStatement );
       pszErrMsg = sqlite3GetError( pDb, &errCode );
       hb_errRT_SQLT3DD( EG_OPEN, ESQLDD_STMTALLOC, pszErrMsg, hb_itemGetCPtr( pItem ), errCode );

--- a/src/rtl/gtcrs/gtcrs.h
+++ b/src/rtl/gtcrs/gtcrs.h
@@ -62,7 +62,15 @@
 #if defined( HB_OS_HPUX )
 #  define _XOPEN_SOURCE_EXTENDED
 #endif
+
+#if defined( HB_OS_SUNOS ) && defined( __GNUC__ ) && __GNUC__ == 15
+#define bool curses_bool  /* work around /usr/gcc/15/lib/gcc/x86_64-pc-solaris2.11/15.2.0/include-fixed/curses.h:89:14: error: ‘bool’ cannot be defined via ‘typedef’ */
 #include <curses.h>
+#undef bool
+#else
+#include <curses.h>
+#endif
+
 #if defined( HB_OS_SUNOS ) || \
     defined( __PDCURSES__ ) || \
     defined( HB_OS_MINIX )

--- a/src/vm/dlmalloc.c
+++ b/src/vm/dlmalloc.c
@@ -4104,6 +4104,7 @@ static void add_segment(mstate m, char* tbase, size_t tsize, flag_t mmapped) {
       break;
   }
   assert(nfences >= 2);
+  (void)nfences;  /* silence the unused variable warning */
 
   /* Insert the rest of old top into a bin as an ordinary free chunk */
   if (csp != old_top) {

--- a/src/vm/macro.c
+++ b/src/vm/macro.c
@@ -745,7 +745,7 @@ char * hb_macroTextSymbol( const char * szString, HB_SIZE nLength, HB_BOOL * pfN
          {
             if( szResult == szString )
             {
-#if defined( HB_OS_WIN ) && defined( HB_GCC_HAS_DIAG ) && ( HB_GCC_VER >= 1500 )
+#if ( defined( HB_OS_SUNOS ) || defined( HB_OS_WIN ) ) && defined( HB_GCC_HAS_DIAG ) && ( HB_GCC_VER >= 1500 )
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wstringop-overflow"
 #  pragma GCC diagnostic ignored "-Wrestrict"
@@ -753,7 +753,7 @@ char * hb_macroTextSymbol( const char * szString, HB_SIZE nLength, HB_BOOL * pfN
                szResult = ( char * ) memcpy( hb_xgrab( nLength + 1 ),
                                              szString, nLength );
                szResult[ nLength ] = '\0';
-#if defined( HB_OS_WIN ) && defined( HB_GCC_HAS_DIAG ) && ( HB_GCC_VER >= 1500 )
+#if ( defined( HB_OS_SUNOS ) || defined( HB_OS_WIN ) ) && defined( HB_GCC_HAS_DIAG ) && ( HB_GCC_VER >= 1500 )
 #  pragma GCC diagnostic push
 #endif
             }


### PR DESCRIPTION
```
2026-08-26 19:55 UTC+0100 Phil Krylov (phil a t krylov.eu)
  * .github/workflows/vm2-ci.yml
    ! Fixed OmniOS release number to match VM.

  * .github/workflows/windows-ci.yml
    ! MSYS2 no longer ships 32-bit allegro, cairo, and ghostscript.

  * contrib/hbhpdf/3rd/libhpdf/hpdfstre.c
    ! Fix accidental usage of variable-length arrays extension.

  * contrib/hbzebra/datamtrx.c
    ! Extend -Warray-bounds warning pacification to GCC 16.

  * contrib/sddsqlt3/core.c
    ! Fix an unused assignment warning.

  * src/rtl/gtcrs/gtcrs.h
    ! Fix building on Oracle Solaris with GCC 15 and native curses.h.

  * src/vm/dlmalloc.c
    ! Silence an unused variable warning when assertions are off.

  * src/vm/macro.c
    ! Extend GCC 15+ -Wstringop-overflow warning pacification to Solaris.
```
